### PR TITLE
feat: JPA 공통 엔티티&ErrorCode&글로벌 예외 처리&공통 응답 구조 설계

### DIFF
--- a/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
+++ b/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
@@ -1,5 +1,4 @@
 package com.cotato.itda.global.common.response;
-package com.cotato.itda.global.common.response;
 
 import java.time.LocalDateTime;
 import java.util.Map;

--- a/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
+++ b/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
@@ -1,0 +1,147 @@
+package com.cotato.itda.global.common.response;
+package com.cotato.itda.global.common.response;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	/**
+	 * 요청 성공 여부
+	 * - true  : 비즈니스 로직이 정상 처리된 경우
+	 * - false : 비즈니스 예외나 시스템 예외 등으로 실패한 경우
+	 */
+	private final boolean success;
+
+	/**
+	 * HTTP 상태 코드 숫자 값 (200, 400, 401, 500 등)
+	 */
+	private final int status;
+
+	/**
+	 * 우리 서비스의 에러 코드
+	 * - 예) USER_ERROR_404_NOT_FOUND
+	 * - 성공 응답의 경우 "SUCCESS"
+	 */
+	private final String code;
+
+	/**
+	 * 사용자/클라이언트에게 노출할 메시지
+	 * - 예외 상황 설명, 성공 메시지 등
+	 */
+	private final String message;
+
+	/**
+	 * 실제 비즈니스 데이터
+	 * - 성공 응답에서만 세팅
+	 */
+	private final T data;
+
+	/**
+	 * 요청 경로 (URI) – 주로 에러 응답에 포함
+	 * - HTTP 요청이 발생한 URI를 기록한다.
+	 * - 예) `/api/v1/users/100`
+	 * - 에러 응답 시, 클라이언트가 어떤 요청 경로에서 에러가 발생했는지 명확하게 파악하도록 돕는다.
+	 */
+	private final String path;
+
+	/**
+	 * 응답 시각
+	 */
+	private final LocalDateTime timestamp;
+
+	/**
+	 * 추가 상세 정보 (필드 검증 오류, 도메인별 이유 등)
+	 * - key: 필드명, 상황 코드 등
+	 * - value: 상세 메시지 또는 값
+	 * - 주로 에러 응답에서 사용되며, 세부적인 에러 발생 이유를 제공한다.
+	 * - 예시 1) 필드 검증 오류 (Validation Error):
+	 * - key: "username", value: "사용자 이름은 5자 이상이어야 합니다."
+	 * - key: "password", value: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다."
+	 * - 예시 2) 도메인별 상세 오류:
+	 * - key: "account_status", value: "정지된 계정으로는 작업을 수행할 수 없습니다."
+	 */
+	private final Map<String, Object> reasons;
+
+	private ApiResponse(
+		boolean success,
+		int status,
+		String code,
+		String message,
+		T data,
+		String path,
+		LocalDateTime timestamp,
+		Map<String, Object> reasons
+	) {
+		this.success = success;
+		this.status = status;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+		this.path = path;
+		this.timestamp = timestamp;
+		this.reasons = reasons;
+	}
+
+	// ==========================
+	// 성공 응답용 팩토리 메서드
+	// ==========================
+
+	/**
+	 * 기본 200 OK 성공 응답
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return success(data, HttpStatus.OK);
+	}
+
+	/**
+	 * 상태 코드를 지정하는 성공 응답
+	 * - 예) 생성 시 201 Created
+	 */
+	public static <T> ApiResponse<T> success(T data, HttpStatus status) {
+		return new ApiResponse<>(
+			true,
+			status.value(),
+			"SUCCESS",
+			"요청이 성공적으로 처리되었습니다.",
+			data,
+			null,          // path는 필요시 컨트롤러/핸들러에서 넣어도 됨
+			LocalDateTime.now(),
+			null
+		);
+	}
+
+	// ==========================
+	// 에러 응답용 팩토리 메서드
+	// ==========================
+
+	public static ApiResponse<Void> error(ErrorCode errorCode, String path) {
+		return error(errorCode, path, null);
+	}
+
+	public static ApiResponse<Void> error(
+		ErrorCode errorCode,
+		String path,
+		Map<String, Object> reasons
+	) {
+		return new ApiResponse<>(
+			false,
+			errorCode.getHttpStatus().value(),
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			null,                 // 실패이므로 data 없음
+			path,
+			LocalDateTime.now(),
+			reasons
+		);
+	}
+}

--- a/src/main/java/com/cotato/itda/global/config/JpaConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/JpaConfig.java
@@ -1,0 +1,27 @@
+package com.cotato.itda.global.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * JPA Auditing 공통 설정.
+ *
+ * - @EnableJpaAuditing 을 통해 @CreatedDate / @LastModifiedDate
+ *   (및 @CreatedBy / @LastModifiedBy) 기능을 활성화한다.
+ * - JPA/Auditing 관련 설정은 이 클래스에서 관리한다.
+ *
+ * AuditorAware 구현 등 추가 설정이 필요할 경우
+ * 이 클래스에 Bean 으로 함께 정의한다.
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+	// 예시)
+	// @Bean
+	// public AuditorAware<Long> auditorAware() {
+	//     // SecurityContext 에서 현재 로그인한 회원 ID 조회해서 반환
+	// }
+}
+

--- a/src/main/java/com/cotato/itda/global/entity/BaseEntity.java
+++ b/src/main/java/com/cotato/itda/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.cotato.itda.global.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+/**
+ * Auto Increment를 쓰는 대부분의 엔티티는
+ * BaseEntity를 상속받아 id 필드를 가지게 된다.
+ * - 이 클래스를 엔티티의 부모 클래스로 사용하겠다는 의미
+ * - 이 클래스 자체로는 테이블이 생성되지 않는다.
+ *
+ * (중요) 만약 Auto Increment가 아닌 다른 전략을 쓰는 엔티티가 있다면
+ * 해당 엔티티에서 id 필드를 별도로 정의해야 한다.
+ * - 해당 엔티티는 BaseTimeEntity를 상속받아도 된다.
+ */
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+}

--- a/src/main/java/com/cotato/itda/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/cotato/itda/global/entity/BaseTimeEntity.java
@@ -1,0 +1,41 @@
+package com.cotato.itda.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+/**
+ *  이 클래스를 엔티티의 부모 클래스로 사용하겠다는 의미
+ *  - 이 클래스 자체로는 테이블이 생성되지 않는다.
+ *  - 대신, 이 클래스를 상속하는 @Entity 클래스의 테이블에
+ *    여기서 정의한 필드(createdAt, updateAt)가 컬럼으로 매핑된다.
+ *  - JPA에서 직접 조회/저장할 수 있는 대상은 @Entity뿐이고,
+ *    @MappedSuperclass는 "공통 매핑 정보를 물려주는 용도"라고 이해하면 된다.
+ */
+@EntityListeners(AuditingEntityListener.class)
+/**
+ * - 엔티티의 생명주기 이벤트(저장, 수정 등)를 가로채서
+ * createdAt, updatedAt 같은 필드를 자동으로 채워주는 리스너를 등록
+ * - Spring Data JPA가 제공하는 AuditingEntityListener가
+ * @CreatedDate, @LastModifiedDate가 붙은 필드를 보고
+ * INSERT 시점 / UPDATE 시점에 알맞은 시간 값을 넣어 준다.
+ * - 이 기능을 쓰려면 별도로 @EnableJpaAuditing 설정이 필요하다.
+ */
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/cotato/itda/global/error/constant/ErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.cotato.itda.global.error.constant;
+
+public interface ErrorCode {
+	String getCode();
+
+	String getMessage();
+
+	String getHttpStatus();
+}

--- a/src/main/java/com/cotato/itda/global/error/constant/ErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/ErrorCode.java
@@ -1,9 +1,11 @@
 package com.cotato.itda.global.error.constant;
 
+import org.springframework.http.HttpStatus;
+
 public interface ErrorCode {
 	String getCode();
 
 	String getMessage();
 
-	String getHttpStatus();
+	HttpStatus getHttpStatus();
 }

--- a/src/main/java/com/cotato/itda/global/error/constant/GlobalErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/GlobalErrorCode.java
@@ -1,0 +1,179 @@
+package com.cotato.itda.global.error.constant;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+	// ========================
+	// 400 Bad Request (요청 자체가 잘못된 경우)
+	// ========================
+
+	/**
+	 * JSON 형식은 맞지만, 비즈니스 규칙상 성립하지 않는 요청일 때 사용.
+	 * 예) 퀴즈 마감 시간이 이미 지났는데 제출을 시도, 범위를 벗어난 숫자 요청 등
+	 */
+	INVALID_REQUEST(
+		HttpStatus.BAD_REQUEST,
+		"CLIENT_ERROR_400_INVALID_REQUEST",
+		"유효하지 않은 요청입니다."
+	),
+
+	/**
+	 * @Valid, Bean Validation, 바인딩 오류 등 필드 단위 검증 실패.
+	 * 예) 필수 필드 누락, 이메일 형식 아님, 문자열 길이 초과 등
+	 */
+	VALIDATION_ERROR(
+		HttpStatus.BAD_REQUEST,
+		"CLIENT_ERROR_400_VALIDATION_ERROR",
+		"요청 값이 유효하지 않습니다."
+	),
+
+	// ========================
+	// 401 Unauthorized (인증 문제)
+	// ========================
+
+	/**
+	 * 인증 자체가 안 된 상태.
+	 * 예) Authorization 헤더 없음, 로그인 안 된 사용자가 보호된 API 호출
+	 */
+	UNAUTHORIZED(
+		HttpStatus.UNAUTHORIZED,
+		"CLIENT_ERROR_401_UNAUTHORIZED",
+		"인증이 필요합니다."
+	),
+
+	/**
+	 * 토큰 구조/서명/파싱에 문제가 있는 경우.
+	 * 예) Bearer 토큰이 아닌 문자열, 서명 검증 실패, 잘못된 형식의 JWT 등
+	 */
+	INVALID_TOKEN(
+		HttpStatus.UNAUTHORIZED,
+		"CLIENT_ERROR_401_INVALID_TOKEN",
+		"유효하지 않은 인증 토큰입니다."
+	),
+
+	/**
+	 * exp가 지난 JWT 토큰을 사용했을 때.
+	 * 예) 이미 만료된 액세스 토큰으로 API 호출
+	 */
+	EXPIRED_TOKEN(
+		HttpStatus.UNAUTHORIZED,
+		"CLIENT_ERROR_401_EXPIRED_TOKEN",
+		"만료된 인증 토큰입니다."
+	),
+
+	// ========================
+	// 403 Forbidden (인가/권한 문제)
+	// ========================
+
+	/**
+	 * 인증은 되었지만, 권한이 부족한 경우.
+	 * 예) 본인이 아닌 다른 사용자의 리소스에 접근, ROLE_USER로 관리자 API 호출
+	 */
+	FORBIDDEN(
+		HttpStatus.FORBIDDEN,
+		"CLIENT_ERROR_403_FORBIDDEN",
+		"접근 권한이 없습니다."
+	),
+
+	// ========================
+	// 404 Not Found (리소스 없음)
+	// ========================
+
+	/**
+	 * 요청한 리소스가 존재하지 않을 때 사용하는 기본 404.
+	 * 예) 없는 placeId로 장소 조회, 탈퇴한 회원 조회 등
+	 */
+	NOT_FOUND(
+		HttpStatus.NOT_FOUND,
+		"CLIENT_ERROR_404_NOT_FOUND",
+		"요청한 리소스를 찾을 수 없습니다."
+	),
+
+	// ========================
+	// 409 Conflict (상태 충돌)
+	// ========================
+
+	/**
+	 * 이미 동일한 리소스가 있을 때.
+	 * 예) 이미 존재하는 이메일로 회원가입, 같은 장소 이름을 중복 등록 시도 등
+	 */
+	DUPLICATE_RESOURCE(
+		HttpStatus.CONFLICT,
+		"CLIENT_ERROR_409_DUPLICATE_RESOURCE",
+		"이미 존재하는 리소스입니다."
+	),
+
+	// ========================
+	// 429 Too Many Requests (요청 과다)
+	// ========================
+
+	/**
+	 * Rate Limit, Flooding 방지 등으로 요청을 제한할 때.
+	 * 예) 짧은 시간 내에 로그인 시도/외부 API 호출을 과도하게 반복
+	 */
+	TOO_MANY_REQUESTS(
+		HttpStatus.TOO_MANY_REQUESTS,
+		"CLIENT_ERROR_429_TOO_MANY_REQUESTS",
+		"요청이 너무 많습니다."
+	),
+
+	// ========================
+	// 5xx Server Errors (서버/인프라/외부 의존성 문제)
+	// ========================
+
+	/**
+	 * 예상하지 못한 서버 내부 예외의 기본값.
+	 * 예) NullPointerException, 처리하지 않은 런타임 예외 등
+	 */
+	INTERNAL_SERVER_ERROR(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"SERVER_ERROR_500_INTERNAL_SERVER_ERROR",
+		"서버 내부 오류입니다."
+	),
+
+	/**
+	 * DB 쿼리/연결 등 데이터베이스 관련 예외.
+	 * 예) Unique 제약 위반, FK 제약 위반, DB 연결 끊김 등
+	 */
+	DATABASE_ERROR(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"SERVER_ERROR_500_DATABASE_ERROR",
+		"데이터베이스 처리 중 오류가 발생했습니다."
+	),
+
+	/**
+	 * OpenWeather, Kakao 등 외부 API 호출에 실패했을 때.
+	 * 예) 외부 서버 5xx, 타임아웃, 응답 포맷 깨짐, 네트워크 장애 등
+	 */
+	EXTERNAL_API_ERROR(
+		HttpStatus.BAD_GATEWAY,
+		"SERVER_ERROR_502_EXTERNAL_API_ERROR",
+		"외부 API 통신 오류입니다."
+	);
+
+	/**
+	 * HTTP 상태 코드 (예: 400, 401, 403, 404, 500...)
+	 * 클라이언트/게이트웨이에서 공통적으로 이해하는 표준 상태 코드.
+	 */
+	private final HttpStatus httpStatus;
+
+	/**
+	 * 우리 서비스 내부에서 쓰는 식별용 에러 코드.
+	 * - 로그/모니터링/프론트 분기에서 사용
+	 * - message는 나중에 바뀌어도 되지만, code는 되도록 안정적으로 유지
+	 */
+	private final String code;
+
+	/**
+	 * 사용자/클라이언트에게 노출할 메시지.
+	 * - 기본 한국어 설명
+	 * - 나중에 i18n(다국어) 적용 시 이 필드를 locale에 맞게 변환해서 내려줄 수 있음
+	 */
+	private final String message;
+}

--- a/src/main/java/com/cotato/itda/global/error/constant/KakaoErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/KakaoErrorCode.java
@@ -1,0 +1,74 @@
+package com.cotato.itda.global.error.constant;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum KakaoErrorCode implements ErrorCode {
+
+	// 400 Bad Request
+	INVALID_KAKAO_AUTHORIZATION_CODE(
+		HttpStatus.BAD_REQUEST,
+		"유효하지 않은 카카오 인가 코드입니다.",
+		"KAKAO_ERROR_400_INVALID_AUTHORIZATION_CODE"
+	),
+
+	MISSING_KAKAO_USER_ID(
+		HttpStatus.BAD_REQUEST,
+		"카카오에서 사용자 식별 정보를 반환하지 않았습니다.",
+		"KAKAO_ERROR_400_MISSING_USER_ID"
+	),
+
+	MISSING_REQUIRED_KAKAO_PROFILE(
+		HttpStatus.BAD_REQUEST,
+		"카카오에서 필수 프로필 정보를 반환하지 않았습니다.",
+		"KAKAO_ERROR_400_MISSING_REQUIRED_PROFILE"
+	),
+
+	// 401 Unauthorized
+	INVALID_KAKAO_ACCESS_TOKEN(
+		HttpStatus.UNAUTHORIZED,
+		"유효하지 않은 카카오 액세스 토큰입니다.",
+		"KAKAO_ERROR_401_INVALID_ACCESS_TOKEN"
+	),
+
+	EXPIRED_KAKAO_ACCESS_TOKEN(
+		HttpStatus.UNAUTHORIZED,
+		"만료된 카카오 액세스 토큰입니다.",
+		"KAKAO_ERROR_401_EXPIRED_ACCESS_TOKEN"
+	),
+
+	// 409 Conflict
+	KAKAO_ACCOUNT_ALREADY_LINKED(
+		HttpStatus.CONFLICT,
+		"이미 다른 계정에 연동된 카카오 계정입니다.",
+		"KAKAO_ERROR_409_ACCOUNT_ALREADY_LINKED"
+	),
+
+	// 502 Bad Gateway (Upstream Kakao 장애)
+	KAKAO_TOKEN_REQUEST_FAILED(
+		HttpStatus.BAD_GATEWAY,
+		"카카오 토큰 발급 요청 중 오류가 발생했습니다.",
+		"KAKAO_ERROR_502_TOKEN_REQUEST_FAILED"
+	),
+
+	KAKAO_USERINFO_REQUEST_FAILED(
+		HttpStatus.BAD_GATEWAY,
+		"카카오 사용자 정보 조회 중 오류가 발생했습니다.",
+		"KAKAO_ERROR_502_USERINFO_REQUEST_FAILED"
+	),
+
+	// 503 Service Unavailable
+	KAKAO_SERVICE_UNAVAILABLE(
+		HttpStatus.SERVICE_UNAVAILABLE,
+		"카카오 서비스가 일시적으로 응답하지 않습니다.",
+		"KAKAO_ERROR_503_SERVICE_UNAVAILABLE"
+	);
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/cotato/itda/global/error/constant/UserErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/UserErrorCode.java
@@ -1,0 +1,44 @@
+package com.cotato.itda.global.error.constant;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+	// 404
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.", "USER_ERROR_404_NOT_FOUND"),
+
+	// 400
+	DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.", "USER_ERROR_400_DUPLICATE_EMAIL"),
+	DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다.", "USER_ERROR_400_DUPLICATE_NICKNAME"),
+	INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다.", "USER_ERROR_400_INVALID_VERIFICATION_CODE"),
+	EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다.", "USER_ERROR_400_EXPIRED_VERIFICATION_CODE"),
+	SOCIAL_PROVIDER_MISMATCH(HttpStatus.BAD_REQUEST, "다른 소셜 제공자로 이미 가입된 계정입니다.",
+		"USER_ERROR_400_SOCIAL_PROVIDER_MISMATCH"),
+
+	// 401
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다.", "USER_ERROR_401_INVALID_PASSWORD"),
+
+	// 403
+	INVALID_ACCOUNT_STATUS(HttpStatus.FORBIDDEN, "계정 상태가 유효하지 않습니다.", "USER_ERROR_403_INVALID_ACCOUNT_STATUS"),
+	EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다.", "USER_ERROR_403_EMAIL_NOT_VERIFIED"),
+	ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "잠금 처리된 계정입니다.", "USER_ERROR_403_ACCOUNT_LOCKED"),
+	WITHDRAWN_USER(HttpStatus.FORBIDDEN, "탈퇴 처리된 계정입니다.", "USER_ERROR_403_WITHDRAWN_USER"),
+
+	// 409
+	SOCIAL_ACCOUNT_ALREADY_LINKED(HttpStatus.CONFLICT, "이미 다른 계정에 연동된 소셜 계정입니다.",
+		"USER_ERROR_409_SOCIAL_ACCOUNT_ALREADY_LINKED"),
+
+	// 429
+	LOGIN_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "로그인 시도 제한을 초과했습니다.",
+		"USER_ERROR_429_LOGIN_ATTEMPT_LIMIT_EXCEEDED");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+}
+

--- a/src/main/java/com/cotato/itda/global/error/exception/BusinessException.java
+++ b/src/main/java/com/cotato/itda/global/error/exception/BusinessException.java
@@ -1,0 +1,40 @@
+package com.cotato.itda.global.error.exception;
+
+import java.util.Map;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	/**
+	 * 우리 서비스에서 정의한 에러 코드 (HttpStatus, Code, Message 정보 포함)
+	 * 예) USER_NOT_FOUND, INVALID_PASSWORD
+	 */
+	private final ErrorCode errorCode;
+	private final Map<String, Object> reasons;
+
+	/**
+	 * 예외 발생에 대한 추가적인 상세 정보이다.
+	 * key: 필드명 또는 상황 코드, value: 상세 메시지
+	 */
+	public BusinessException(ErrorCode errorCode) {
+		this(errorCode, null);
+	}
+
+	/**
+	 * 전체 생성자: ErrorCode와 상세 정보(reasons)를 포함하여 예외를 생성한다.
+	 *
+	 * @param errorCode 발생한 비즈니스 에러 코드
+	 * @param reasons 예외에 대한 추가 상세 정보 (Map 형태)
+	 */
+	public BusinessException(ErrorCode errorCode, Map<String, Object> reasons) {
+		// 부모 클래스(RuntimeException)의 생성자를 호출한다.
+		// errorCode에 정의된 message가 Exception의 기본 메시지로 설정되어 로그에 기록된다.
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.reasons = reasons;
+	}
+}

--- a/src/main/java/com/cotato/itda/global/error/exception/ValidationException.java
+++ b/src/main/java/com/cotato/itda/global/error/exception/ValidationException.java
@@ -1,0 +1,24 @@
+package com.cotato.itda.global.error.exception;
+
+import java.util.Map;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+
+
+/**
+ * 유효성 검증(Validation) 실패 시 발생하는 비즈니스 예외이다.
+ * * @Valid 또는 @Validated 검증 실패,
+ * 혹은 비즈니스 로직 내에서 데이터 유효성 검증 실패 시 사용한다.
+ * * BusinessException을 상속받으므로, 에러 코드(errorCode)와 상세 정보(reasons)를 포함할 수 있다.
+ * 이 예외는 전역 예외 처리기에서  필드에 필드별 검증 오류 정보를 담아 클라이언트에게 반환할 때 사용된다.
+ */
+public class ValidationException extends BusinessException {
+
+	public ValidationException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ValidationException(ErrorCode errorCode, Map<String, Object> reasons) {
+		super(errorCode, reasons);
+	}
+}

--- a/src/main/java/com/cotato/itda/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/itda/global/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,177 @@
+package com.cotato.itda.global.error.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.error.constant.GlobalErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * 비즈니스 예외 (도메인/서비스 계층에서 명시적으로 던지는 예외)
+	 */
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ApiResponse<Void>> handleBusinessException(
+		BusinessException ex,
+		HttpServletRequest request
+	) {
+		log.warn("[BusinessException] path={}, code={}, message={}",
+			request.getRequestURI(),
+			ex.getErrorCode().getCode(),
+			ex.getMessage()
+		);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			ex.getErrorCode(),
+			request.getRequestURI(),
+			ex.getReasons()
+		);
+
+		return ResponseEntity
+			.status(ex.getErrorCode().getHttpStatus())
+			.body(body);
+	}
+
+	/**
+	 * Bean Validation(@Valid) 실패 – RequestBody, PathVariable, RequestParam 바인딩 에러 처리 핸들러이다.
+	 * Spring의  @Valid 또는 @Validated 어노테이션을 사용한 요청 객체(DTO)의
+	 * 유효성 검증 실패 시 발생하는 예외들을 포착한다.
+	 */
+	@ExceptionHandler({
+		MethodArgumentNotValidException.class, //  @RequestBody 유효성 검증 실패 시 발생 (주로 POST/PUT)
+		BindException.class                   //  @ModelAttribute 또는 @PathVariable, @RequestParam 유효성 검증 실패 시 발생
+	})
+	public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(
+		Exception ex,
+		HttpServletRequest request
+	) {
+		// 1. 유효성 검증 오류의 상세 정보를 담고 있는 BindingResult 객체를 추출하기 위해 초기화한다.
+		BindingResult bindingResult = null;
+
+		// 2. 발생한 예외가 MethodArgumentNotValidException (RequestBody 검증 오류)인 경우
+		if (ex instanceof MethodArgumentNotValidException manve) {
+			// 예외 객체에서 BindingResult를 가져온다. BindingResult에 모든 필드 오류 정보가 담겨 있다.
+			bindingResult = manve.getBindingResult();
+		}
+		// 3. 발생한 예외가 BindException (다른 타입 바인딩/검증 오류)인 경우
+		else if (ex instanceof BindException be) {
+			// BindException 객체에서 BindingResult를 가져온다.
+			bindingResult = be.getBindingResult();
+		}
+
+		// 4. 클라이언트에게 전달할 상세 오류 정보 (reasons)를 저장할 Map을 초기화한다.
+		Map<String, Object> reasons = new HashMap<>();
+
+		// 5. BindingResult가 정상적으로 추출되었으면 (유효성 검증 오류가 실제로 발생했다면)
+		if (bindingResult != null) {
+			// 6. BindingResult에 담긴 모든 FieldError를 순회한다.
+			for (FieldError fieldError : bindingResult.getFieldErrors()) {
+				// 7. reasons Map에 '필드명'을 Key로, '오류 메시지'를 Value로 저장한다.
+				//    예) {"username": "사용자 이름은 필수 항목입니다."}
+				reasons.put(fieldError.getField(), fieldError.getDefaultMessage());
+			}
+		}
+
+		// 8. 서버 로그에 요청 경로와 추출된 상세 오류 정보(reasons)를 기록한다.
+		log.warn("[Validation] path={}, reasons={}", request.getRequestURI(), reasons);
+
+		// 9. GlobalErrorCode.VALIDATION_ERROR 정보를 바탕으로 ApiResponse<Void> 에러 바디를 생성한다.
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.VALIDATION_ERROR, // 서비스 표준 유효성 에러 코드 (HTTP 400 Bad Request)
+			request.getRequestURI(),
+			reasons // 상세 오류 정보 Map을 reasons 필드에 포함시킨다.
+		);
+
+		// 10. HTTP 상태 코드와 에러 바디를 담은 ResponseEntity를 최종 반환한다.
+		return ResponseEntity
+			.status(GlobalErrorCode.VALIDATION_ERROR.getHttpStatus())
+			.body(body);
+	}
+
+	/**
+	 * JSON 파싱 실패 (바디 형식이 이상한 경우)
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException ex,
+		HttpServletRequest request
+	) {
+		log.warn("[HttpMessageNotReadable] path={}, message={}",
+			request.getRequestURI(),
+			ex.getMessage()
+		);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.INVALID_REQUEST,
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(GlobalErrorCode.INVALID_REQUEST.getHttpStatus())
+			.body(body);
+	}
+
+	/**
+	 * 지원하지 않는 HTTP 메서드
+	 */
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(
+		HttpRequestMethodNotSupportedException ex,
+		HttpServletRequest request
+	) {
+		log.warn("[MethodNotSupported] path={}, method={}",
+			request.getRequestURI(),
+			ex.getMethod()
+		);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.INVALID_REQUEST,
+			request.getRequestURI(),
+			Map.of("method", ex.getMethod())
+		);
+
+		return ResponseEntity
+			.status(GlobalErrorCode.INVALID_REQUEST.getHttpStatus())
+			.body(body);
+	}
+
+
+	/**
+	 * 그 외 처리하지 못한 모든 예외에 대한 마지막 방어선
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleException(
+		Exception ex,
+		HttpServletRequest request
+	) {
+		log.error("[UnhandledException] path=" + request.getRequestURI(), ex);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.INTERNAL_SERVER_ERROR,
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+			.body(body);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
- #3 
- #4  

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

- JPA Auditing 공통 설정 클래스 `JpaConfig` 추가 (`@EnableJpaAuditing`)
- 생성/수정 시간 공통 관리를 위한 `BaseTimeEntity` 도입
- Auto Increment PK 공통화를 위한 `BaseEntity` 도입 (`id` + 시간 필드 상속)
- 전역/도메인/외부 연동 에러코드 인터페이스 `ErrorCode` 정의
- 글로벌 공통 에러코드 `GlobalErrorCode` 설계 및 적용
- 카카오 로그인/연동 관련 에러코드 `KakaoErrorCode` 설계
- 사용자 도메인 전용 에러코드 `UserErrorCode` 설계

- 성공/실패 응답을 모두 `ApiResponse<T>`로 통일
- 도메인/비즈니스 예외용 `BusinessException`, `ValidationException` 설계
- `ErrorCode` 인터페이스 + `GlobalErrorCode`/`UserErrorCode`/`KakaoErrorCode`와 연동
- `GlobalExceptionHandler`를 통해 공통 에러 응답 반환
- 샘플 컨트롤러/서비스에서 공통 응답 DTO 사용하도록 리팩토링(필요 시)


## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요. -->
- 해당 사항 없음 (설정/백엔드 인프라 관련 변경)

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->

- `GlobalErrorCode`, `KakaoErrorCode`, `UserErrorCode`에서
  - HTTP 상태 코드 매핑
  - 코드 문자열 네이밍 컨벤션(`CLIENT_ERROR_4xx_...`, `KAKAO_ERROR_...`, `USER_ERROR_...`)
  이 괜찮은지, 추가/제거하면 좋을 항목 있으면 의견 부탁드립니다.
