### PR TITLE
[fix] CD docker-compose를 최신 docker compose로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,7 +75,7 @@ jobs:
           envs: DB_URL, DB_USERNAME, DB_PASSWORD
           script: |
             cd /home/ubuntu/compose
-            sudo docker-compose -f docker-compose.prod.yml down
+            sudo docker compose -f docker-compose.prod.yml down
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/symtalk-be
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/nginx
-            sudo -E DB_URL=$DB_URL DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD docker-compose -f docker-compose.prod.yml up -d
+            sudo -E DB_URL=$DB_URL DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## #️⃣연관된 이슈

#7 

## 📝작업 내용

cd.yml의 `docker-compose`를 `docker compose`로 수정
- docker-compose: 별도로 설치해야 하는 독립 실행 파일로 공식 지원 종료
- docker compose: Docker CLI의 플러그인으로 내장, 별도 설치 불필요

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

