### PR TITLE
[fix] 환경변수 대신 github secrets 사용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,4 +78,4 @@ jobs:
             sudo docker compose -f docker-compose.prod.yml down
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/symtalk-be
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/nginx
-            sudo -E DB_URL=$DB_URL DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD docker compose -f docker-compose.prod.yml up -d
+            sudo DB_URL=$DB_URL DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## #️⃣연관된 이슈

#7 

## 📝작업 내용

`sudo -E DB_URL=$DB_URL`의 EC2 환경 변수 사용에서
`sudo DB_URL=$DB_URL`의 github secrets를 사용하는 방식으로 변경

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
