### PR TITLE
fix: 성공응답 200 OK 로 통일

### DIFF
--- a/docs/api-response-spec.md
+++ b/docs/api-response-spec.md
@@ -15,6 +15,7 @@
 ### 1.1 JSON 구조
 
 백엔드에서 사용하는 공통 응답 DTO는 아래와 같은 구조를 갖습니다.
+- 성공 시에는 200 OK 상태 고정합니다.
 
 ```json
 {
@@ -27,7 +28,7 @@
     "email": "gimin1463@naver.com",
     "nickname": "기민"
   },
-  "path": "/api/users/1",
+  "path": null,
   "timestamp": "2025-11-28T11:23:45.123",
   "reasons": null
 }
@@ -42,7 +43,7 @@
     - `false` : 비즈니스 예외 / 검증 실패 / 시스템 예외 등 실패한 경우
 - `status` (number)
     - HTTP 상태 코드 숫자 값.
-    - 예: `200`, `201`, `400`, `401`, `403`, `404`, `500` 등.
+    - 예: `200`, `400`, `401`, `403`, `404`, `500` 등.
 - `code` (string)
     - 우리 서비스에서 정의한 에러/상태 코드 문자열.
     - 성공 응답: `"SUCCESS"`
@@ -60,6 +61,7 @@
     - 실패(`success = false`)인 경우에는 항상 `null`.
 - `path` (string or null)
     - 요청 경로(URI).
+    - 성공 응답에서는 null이며, 에러 응답에서는 요청 URL를 포함한다.
     - 예: `/api/users/1`, `/api/auth/kakao/login`
     - 주로 에러 응답에서 어떤 요청에서 에러가 났는지 디버깅용으로 활용.
 - `timestamp` (string)
@@ -77,7 +79,7 @@
 
 ## 2. 성공 응답 예시
 
-### 2.1 단일 리소스 조회
+### 성공 응답은 모두 200 OK 상태이며, `success`가 `true`로 설정됩니다.
 
 ```json
 {
@@ -90,28 +92,10 @@
     "email": "gimin1463@naver.com",
     "nickname": "기민"
   },
-  "path": "/api/users/1",
+  "path": null,
   "timestamp": "2025-11-28T11:23:45.123",
-  "reasons": null}
-
-```
-
-### 2.2 리소스 생성 (201 Created)
-
-```json
-{
-  "success": true,
-  "status": 201,
-  "code": "SUCCESS",
-  "message": "요청이 성공적으로 처리되었습니다.",
-  "data": {
-    "id": 10,
-    "email": "gimin@google.com",
-    "nickname": "기민2"
-  },
-  "path": "/api/users",
-  "timestamp": "2025-11-28T11:30:00.000",
-  "reasons": null}
+  "reasons": null
+}
 
 ```
 
@@ -159,7 +143,7 @@
 
 ```
 
-- DTO에 선언한 `@NotBlank`, `@Email` 등의 메시지가 `reasons`에 맵핑된다.
+- DTO에 선언한 `@NotBlank`, `@Email` 등의 메시지가 `reasons`에 매핑된다.
 - `reasons`의 key = 필드명, value = 에러 메시지.
 
 ### 3.3 카카오 로그인/연동 에러

--- a/docs/backend-error-handling-guide.md
+++ b/docs/backend-error-handling-guide.md
@@ -14,6 +14,7 @@
 
 1. **컨트롤러는 성공 응답만 직접 만든다.**
     - 성공 시: `ApiResponse.success(...)` 사용
+    - 모든 성공 응답(생성 포함)은 HTTP 200 OK로 통일한다.
     - 실패 시: 예외를 던지고 글로벌 핸들러에 위임
 2. **비즈니스 실패는 서비스/도메인에서 `BusinessException` 또는 `ValidationException`을 던진다.**
     - “기대한 실패”는 모두 ErrorCode 기반 예외로 표현
@@ -32,7 +33,10 @@
 
 ```java
 public static <T> ApiResponse<T> success(T data);
-public static <T> ApiResponse<T> success(T data, HttpStatus status);
+// public -> private로 변경
+// 200 OK로 성공 응답 고정 
+// 밑의 private는 내부에서만 사용
+private static <T> ApiResponse<T> success(T data, HttpStatus status);
 
 public static ApiResponse<Void> error(ErrorCode errorCode, String path);
 public static ApiResponse<Void> error(ErrorCode errorCode, String path, Map<String, Object> reasons);
@@ -152,6 +156,8 @@ public class ValidationException extends BusinessException {
 ### 3.1 성공 응답만 직접 작성
 
 컨트롤러는 **정상 플로우**에만 집중한다.
+성공 응답은 200 OK로 고정한다.
+- 컨트롤러는 기본적으로 ApiResponse.success(...)만 반환한다.
 
 ```java
 @RestController
@@ -162,19 +168,17 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<UserResponse>> getUser(@PathVariable Long id) {
+    public ApiResponse<UserResponse> getUser(@PathVariable Long id) {
         UserResponse response = userService.getUser(id);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ApiResponse.success(response);
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<UserResponse>> createUser(
+    public ApiResponse<UserResponse> createUser(
         @Valid @RequestBody UserCreateRequest request
     ) {
         UserResponse response = userService.createUser(request);
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponse.success(response, HttpStatus.CREATED));
+        return ApiResponse.success(response);
     }
 }
 
@@ -188,7 +192,7 @@ public class UserController {
     // ❌ 이렇게 하지 말 것
     try {
         UserResponse response = userService.getUser(id);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ApiResponse.success(response);
     } catch (BusinessException e) {
         // 여기서 ApiResponse.error(...)를 만들지 않는다.
     }
@@ -385,7 +389,7 @@ if (userRepository.existsByNickname(request.getNickname())) {
 3. 컨트롤러
     - `UserResponse`를 `ApiResponse.success(...)`로 감싸서 반환
 4. 응답
-    - 성공: 201 + `success=true` + `data=UserResponse`
+    - 성공: 200 + `success=true` + `data=UserResponse`
     - 실패(중복 이메일): 400 + `success=false` + `code=USER_ERROR_400_DUPLICATE_EMAIL`
 
 ---

--- a/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
+++ b/src/main/java/com/cotato/itda/global/common/response/ApiResponse.java
@@ -103,10 +103,13 @@ public class ApiResponse<T> {
 	}
 
 	/**
+	 * 현재 단게에서는 성공 응답 200 OK로 고정
+	 * 즉, private로 메서드를 두어 내부(기본 200 OK 성공 응답)에서만 사용
+	 * 추후)
 	 * 상태 코드를 지정하는 성공 응답
 	 * - 예) 생성 시 201 Created
 	 */
-	public static <T> ApiResponse<T> success(T data, HttpStatus status) {
+	private static <T> ApiResponse<T> success(T data, HttpStatus status) {
 		return new ApiResponse<>(
 			true,
 			status.value(),
@@ -118,6 +121,7 @@ public class ApiResponse<T> {
 			null
 		);
 	}
+
 
 	// ==========================
 	// 에러 응답용 팩토리 메서드


### PR DESCRIPTION
## #️⃣연관된 이슈
 #26 
<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->

## 📝작업 내용
공통 응답 포맷(ApiResponse<T>)의 성공 응답 정책을 200 OK로 통일했습니다.

컨트롤러는 성공 응답만 반환하고, 실패는 예외를 던져 GlobalExceptionHandler에서 처리하도록 흐름을 정리했습니다.

ApiResponse/예외 처리 관련 문서(api-response-spec.md, backend-error-handling-guide.md)를 현재 코드 정책과 일치하도록 업데이트했습니다.
## 🛠️주요 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 문서 업데이트
- [x] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
