### PR TITLE
[FEAT] WebSocket + STOMP (JWT 인증) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// websocket + STOMP
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	//JJWT
 	implementation "io.jsonwebtoken:jjwt-api:0.13.0"
 	runtimeOnly  "io.jsonwebtoken:jjwt-impl:0.13.0"

--- a/src/main/java/com/cotato/itda/domain/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/config/WebSocketConfig.java
@@ -1,0 +1,83 @@
+package com.cotato.itda.domain.websocket.config;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import com.cotato.itda.domain.websocket.listener.IpHandshakeInterceptor;
+import com.cotato.itda.domain.websocket.security.StompAuthChannelInterceptor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final String[] allowedOriginPatterns;
+	private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+	public WebSocketConfig(
+		@Value("${app.websocket.allowed-origins}") String allowedOrigins,
+		StompAuthChannelInterceptor stompAuthChannelInterceptor
+	) {
+		this.allowedOriginPatterns = parseAllowedOrigins(allowedOrigins);
+		this.stompAuthChannelInterceptor = stompAuthChannelInterceptor;
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		// 클라이언트가 실제로 접속하는 WS 엔드포인트
+		registry.addEndpoint("/ws")
+			// 브라우저 CORS
+			// setAllowedOriginPatterns를 쓰면 와일드카드(*) 사용 가능+ 여러 도메인 허용 가능
+			.setAllowedOriginPatterns(allowedOriginPatterns)
+			//핸드셰이크에서 IP정보 뽑아오는 인터셉터 추가
+			// IP/User-Agent를 session attributes에 저장해두면
+			// 이후에 connect/disconnect 이벤트에서 참조 가능
+			.addInterceptors(new IpHandshakeInterceptor());
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		// 1) 메시지 브로커 (서버 -> 클라이언트 publish)를 단순 브로커로 활성화
+		// - /topic: 1:N 다중 구독 채널용 prefix
+		// - /queue: 1:1 단독 구독 채널용 prefix
+		registry.enableSimpleBroker("/topic", "/queue")
+			// heartbeat 설정: 클라이언트가 10초마다 서버에 ping, 서버는 10초마다 클라이언트에 pong
+			.setHeartbeatValue(new long[] {10000L, 10000L})
+			.setTaskScheduler(heartBeatTaskScheduler());
+
+		// 클라이언트가 SEND 시 사용하는 애플리케이션 prefix
+		registry.setApplicationDestinationPrefixes("/app");
+		registry.setUserDestinationPrefix("/user");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		// CONNECT/SUBSCRIBE/SEND 프레임에서 JWT 인증 처리
+		registration.interceptors(stompAuthChannelInterceptor);
+	}
+
+	@Bean
+	public TaskScheduler heartBeatTaskScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(1);
+		scheduler.setThreadNamePrefix("ws-heartbeat-");
+		scheduler.initialize();
+		return scheduler;
+	}
+
+	private String[] parseAllowedOrigins(String allowedOrigins) {
+		return Arrays.stream(allowedOrigins.split(","))
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.toArray(String[]::new);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/controller/ConnectionController.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/controller/ConnectionController.java
@@ -1,0 +1,71 @@
+package com.cotato.itda.domain.websocket.controller;
+
+import java.security.Principal;
+import java.time.Instant;
+
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.cotato.itda.domain.websocket.dto.ConnectionAckPayload;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ConnectionController {
+
+	// SimpMessagingTemplate은 Spring에서 제공하는 메시징 템플릿으로,
+	// WebSocket을 통해 클라이언트에게 메시지를 보내는 데 사용된다.
+	// 이 템플릿을 사용하면 특정 사용자나 주제(topic)로 메시지를 전송할 수 있다.
+	private final SimpMessagingTemplate simpMessagingTemplate;
+
+	/**
+	 * 클라이언트가 SEND "/app/connection/ack"로 메시지를 보낼 때 호출되는 메서드
+	 * 서버가 클라이언트의 연결을 확인하고, 연결 성공 메시지를 해당 클라이언트에게 전송한다.
+	 * /user/queue/connection/ack 로 메시지를 보내므로, 클라이언트는 /user/queue/connection/ack 을 구독해야 한다.
+	 * <p>
+	 * Param principal 현재 인증된 사용자의 정보를 담고 있는 Principal 객체
+	 * Param sessionId 현재 WebSocket 세션의 ID
+	 */
+	@MessageMapping("/connection/ack")
+	public void ack(
+		Principal principal,
+		@Header("simpSessionId") String sessionId
+	) {
+		if (principal == null) {
+			// 인증되지 않은 사용자 처리
+			log.info("인증되지 않은 사용자가 연결 확인 메시지를 보냈습니다. 세션 ID: {}", sessionId);
+			throw new BusinessException(JwtErrorCode.UNAUTHORIZED);
+		}
+
+		String principalName = principal.getName();
+		log.info("사용자 '{}'가 연결 확인 메시지를 보냈습니다. 세션 ID: {}", principalName, sessionId);
+		ConnectionAckPayload payload = new ConnectionAckPayload(
+			Instant.now().toString(),
+			sessionId,
+			principalName,
+			"WS&STOMP 연결이 성공적으로 설정되었습니다."
+		);
+
+		/**
+		 * 특정 사용자에게 메시지를 보내는 메서드
+		 * @param principalName: 메시지를 받을 사용자의 이름(또는 ID)
+		 * destination: "/queue/connection/ack" - 사용자의 개인 큐로 메시지를 보냄
+		 * 클라이언트는 "/user/queue/connection/ack"을 구독하면 된다
+		 */
+		simpMessagingTemplate.convertAndSendToUser(
+			principalName,
+			"/queue/connection/ack",
+			payload
+		);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ConnectionAckPayload.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ConnectionAckPayload.java
@@ -1,0 +1,9 @@
+package com.cotato.itda.domain.websocket.dto;
+
+public record ConnectionAckPayload(
+	String connectedAt,
+	String sessionId,
+	String principalName,
+	String message
+) {
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/WsErrorPayload.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/WsErrorPayload.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.websocket.dto;
+
+public record WsErrorPayload(
+	String timestamp,
+	String code,
+	String message
+) {}

--- a/src/main/java/com/cotato/itda/domain/websocket/error/WsMessagingExceptionHandler.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/error/WsMessagingExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.cotato.itda.domain.websocket.error;
+
+import java.time.Instant;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import com.cotato.itda.domain.websocket.dto.WsErrorPayload;
+
+/**
+ * WebSocket 메시지 처리 중 발생하는 예외를 처리하는 전역 예외 처리기
+ * 모든 예외를 잡아 WsErrorPayload 형태로 클라이언트에게 전송
+ *
+ * @ControllerAdvice 어노테이션을 사용하여 전역 예외 처리기로 지정
+ * @MessageExceptionHandler 어노테이션을 사용하여 메시지 처리 중 발생하는 예외를 처리
+ * @SendToUser 어노테이션을 사용하여 특정 사용자에게 에러 메시지를 전송
+ */
+@ControllerAdvice
+public class WsMessagingExceptionHandler {
+
+	@MessageExceptionHandler(Exception.class)
+	@SendToUser("/queue/errors")
+	public WsErrorPayload handle(Exception ex) {
+		return new WsErrorPayload(
+			Instant.now().toString(),
+			"WS_MESSAGE_ERROR",
+			ex.getMessage()
+		);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/listener/IpHandshakeInterceptor.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/listener/IpHandshakeInterceptor.java
@@ -1,0 +1,51 @@
+package com.cotato.itda.domain.websocket.listener;
+
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+/**
+ * WebSocket 핸드셰이크(HTTP UPGRADE 요청) 시 클라이언트의 IP 주소와 User-Agent 정보를 추출하여
+ * 세션 속성에 저장하는 인터셉터입니다.
+ */
+public class IpHandshakeInterceptor implements HandshakeInterceptor {
+
+	@Override
+	public boolean beforeHandshake(
+		ServerHttpRequest request,
+		ServerHttpResponse response,
+		WebSocketHandler wsHandler,
+		Map<String, Object> attributes
+	) {
+		// User-Agent 헤더 추출
+		// User-Agent는 클라이언트의 종류 및 버전을 나타내는 문자열
+		HttpHeaders headers = request.getHeaders();
+		String userAgent = headers.getFirst("User-Agent");
+
+		// 클라이언트 IP 주소 추출
+		String clientIp = "unknown";
+		if (request instanceof ServletServerHttpRequest servletRequest) {
+			clientIp = servletRequest.getServletRequest().getRemoteAddr();
+		}
+
+		// 세션 attributes에 저장 -> 나중에 connect/disconnect 이벤트에서 꺼내씀
+		attributes.put("clientIp", clientIp);
+		attributes.put("userAgent", userAgent);
+		return true; // 핸드셰이크 계속 진행
+	}
+
+	@Override
+	public void afterHandshake(
+		ServerHttpRequest request,
+		ServerHttpResponse response,
+		WebSocketHandler wsHandler,
+		Exception exception
+	) {
+		// 핸드셰이크 후 처리할 내용이 없으므로 비워둠
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/listener/WebSocketSessionEventListener.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/listener/WebSocketSessionEventListener.java
@@ -1,0 +1,69 @@
+package com.cotato.itda.domain.websocket.listener;
+
+import java.util.Map;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * - SessionConnectEvent: CONNECT 프레임이 들어온 시점
+ * - SessionConnectedEvent: CONNECT 처리 후 CONNECTED가 나간 시점
+ * - SessionSubscribeEvent: SUBSCRIBE 들어온 시점(채널 추적 가능)
+ * - SessionDisconnectEvent: 연결 종료(정상/비정상 포함)
+ * @EventListener 애노테이션을 사용하여 WebSocket 세션 이벤트를 처리하는 리스너 클래스
+ * - 인자에 해당하는 이벤트가 발생할 때마다 메서드가 호출된다.
+ * 예를 들어, onConnect 메서드는 SessionConnectEvent가 발생할 때 호출된다.
+ */
+@Slf4j
+@Component
+public class WebSocketSessionEventListener {
+
+	//@EventListener는
+	@EventListener
+	public void onConnect(SessionConnectEvent event){
+		StompHeaderAccessor acc = StompHeaderAccessor.wrap(event.getMessage());
+		logCommon("[WS][CONNECT_EVENT]", acc);
+	}
+
+	@EventListener
+	public void onConnected(SessionConnectedEvent event) {
+		StompHeaderAccessor acc = StompHeaderAccessor.wrap(event.getMessage());
+		logCommon("[WS][CONNECTED_EVENT]", acc);
+	}
+
+	@EventListener
+	public void onSubscribe(SessionSubscribeEvent event) {
+		StompHeaderAccessor acc = StompHeaderAccessor.wrap(event.getMessage());
+		String dest = acc.getDestination();
+		logCommon("[WS][SUBSCRIBE_EVENT] dest=" + dest, acc);
+	}
+
+	@EventListener
+	public void onDisconnect(SessionDisconnectEvent event) {
+		StompHeaderAccessor acc = StompHeaderAccessor.wrap(event.getMessage());
+		String closeStatus = (event.getCloseStatus() != null) ? event.getCloseStatus().toString() : "unknown";
+		logCommon("[WS][DISCONNECT_EVENT] closeStatus=" + closeStatus, acc);
+	}
+
+	private void logCommon(String prefix, StompHeaderAccessor acc) {
+		String sessionId = acc.getSessionId();
+
+		// CONNECT 인증이 성공했다면 여기서 user가 잡힌다.
+		String principalName = (acc.getUser() != null) ? acc.getUser().getName() : "anonymous";
+
+		Map<String, Object> attrs = acc.getSessionAttributes();
+		String clientIp = (attrs != null && attrs.get("clientIp") != null) ? attrs.get("clientIp").toString() : "unknown";
+		String userAgent = (attrs != null && attrs.get("userAgent") != null) ? String.valueOf(attrs.get("userAgent")) : "unknown";
+
+		log.info("{} sessionId={} principalName={} clientIp={} userAgent={}",
+			prefix, sessionId, principalName, clientIp, userAgent
+		);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/security/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/security/StompAuthChannelInterceptor.java
@@ -1,0 +1,139 @@
+package com.cotato.itda.domain.websocket.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
+import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+	private final JwtTokenValidator jwtTokenValidator;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+
+		StompHeaderAccessor accessor =
+			MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor == null) {
+			log.warn("[WS][디버그] StompHeaderAccessor를 가져올 수 없음. messageHeaders={}", message.getHeaders());
+			return message;
+		}
+
+		StompCommand command = accessor.getCommand();
+		String sessionId = accessor.getSessionId();
+		String destination = accessor.getDestination();
+
+		String authHeader = accessor.getFirstNativeHeader("Authorization"); // 없으면 null
+
+		// ===== 0) 들어온 프레임 공통 로그 =====
+		// SEND/CONNECT/SUBSCRIBE가 아예 들어오는지부터 확인
+		log.info("[WS][수신] command={}, sessionId={}, destination={}", command, sessionId, destination);
+
+		// Authorization 유무만 표시 (토큰 전문은 절대 로그로 남기지 말기)
+		log.info("[WS][헤더] Authorization 존재 여부={}",
+			(authHeader != null && !authHeader.isBlank())
+		);
+
+		try {
+			// ===== 1) CONNECT 인증 =====
+			if (command == StompCommand.CONNECT) {
+				log.info("[WS][CONNECT] STOMP CONNECT 프레임 인증 시작. sessionId={}", sessionId);
+
+				if (authHeader == null || authHeader.isBlank()) {
+					log.warn("[WS][CONNECT][차단] Authorization 헤더가 없음. sessionId={}", sessionId);
+					throw new BusinessException(JwtErrorCode.MISSING_TOKEN);
+				}
+
+				String token = extractBearerToken(authHeader);
+
+				// 토큰 길이만 로그 (내용 X)
+				log.info("[WS][CONNECT] Bearer 토큰 추출 완료. tokenLength={}, sessionId={}",
+					(token != null ? token.length() : -1), sessionId
+				);
+
+				Claims claims = jwtTokenValidator.validateAndGetClaims(token, JwtPurpose.ACCESS);
+				log.info("[WS][CONNECT] 토큰 검증 성공. claimsSubject={}, sessionId={}",
+					(claims != null ? claims.getSubject() : "null"), sessionId
+				);
+
+				Authentication authentication = jwtTokenProvider.getAuthentication(claims);
+				log.info("[WS][CONNECT] Authentication 생성 성공. username={}, sessionId={}",
+					authentication.getName(), sessionId
+				);
+
+				accessor.setUser(authentication);
+
+				Map<String, Object> attrs = accessor.getSessionAttributes();
+				if (attrs != null) {
+					attrs.put("wsUsername", authentication.getName());
+				}
+
+				log.info("[WS][CONNECT] STOMP 세션 사용자 설정 완료. username={}, sessionId={}",
+					authentication.getName(), sessionId
+				);
+			}
+
+			// ===== 2) CONNECT 이후 프레임(SUBSCRIBE/SEND 등) 인증 확인 =====
+			if (command != null && command != StompCommand.CONNECT) {
+				if (accessor.getUser() == null) {
+					// 여기 걸리면: "CONNECT 때 setUser가 안 됐거나",
+					// "클라이언트가 CONNECT 없이 바로 SEND/SUBSCRIBE를 보냈거나",
+					// "프레임이 다른 세션으로 들어왔거나" 중 하나
+					log.warn("[WS][차단] STOMP {} 거부: 사용자 정보 없음(인증 안 됨). sessionId={}, destination={}",
+						command, sessionId, destination
+					);
+					throw new BusinessException(JwtErrorCode.UNAUTHORIZED);
+				}
+
+				log.info("[WS][통과] STOMP {} 인증된 사용자 확인. username={}, sessionId={}, destination={}",
+					command, accessor.getUser().getName(), sessionId, destination
+				);
+			}
+
+			return message;
+
+		} catch (BusinessException e) {
+			// 비즈니스 예외는 왜 막혔는지 명확히 로그
+			log.warn("[WS][예외] STOMP 처리 중 차단됨. command={}, sessionId={}, destination={}, errorCode={}",
+				command, sessionId, destination, e.getErrorCode()
+			);
+			throw e;
+		} catch (Exception e) {
+			// 예상치 못한 예외
+			log.error("[WS][예외] STOMP 처리 중 알 수 없는 오류. command={}, sessionId={}, destination={}",
+				command, sessionId, destination, e
+			);
+			throw e;
+		}
+	}
+
+	public String extractBearerToken(String authHeader) {
+		String prefix = "Bearer ";
+		if (authHeader.startsWith(prefix)) {
+			return authHeader.substring(prefix.length()).trim();
+		}
+		return authHeader.trim();
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/security/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/security/StompAuthChannelInterceptor.java
@@ -30,104 +30,69 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 	private final JwtTokenValidator jwtTokenValidator;
 	private final JwtTokenProvider jwtTokenProvider;
 
+
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
-
 		StompHeaderAccessor accessor =
 			MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-		if (accessor == null) {
-			log.warn("[WS][디버그] StompHeaderAccessor를 가져올 수 없음. messageHeaders={}", message.getHeaders());
-			return message;
-		}
+		if (accessor == null) return message;
+
+		accessor.setLeaveMutable(true);
 
 		StompCommand command = accessor.getCommand();
 		String sessionId = accessor.getSessionId();
 		String destination = accessor.getDestination();
 
-		String authHeader = accessor.getFirstNativeHeader("Authorization"); // 없으면 null
-
-		// ===== 0) 들어온 프레임 공통 로그 =====
-		// SEND/CONNECT/SUBSCRIBE가 아예 들어오는지부터 확인
 		log.info("[WS][수신] command={}, sessionId={}, destination={}", command, sessionId, destination);
 
-		// Authorization 유무만 표시 (토큰 전문은 절대 로그로 남기지 말기)
-		log.info("[WS][헤더] Authorization 존재 여부={}",
-			(authHeader != null && !authHeader.isBlank())
-		);
-
 		try {
-			// ===== 1) CONNECT 인증 =====
 			if (command == StompCommand.CONNECT) {
-				log.info("[WS][CONNECT] STOMP CONNECT 프레임 인증 시작. sessionId={}", sessionId);
+				String authHeader = accessor.getFirstNativeHeader("Authorization");
+				if (authHeader == null || authHeader.isBlank()) {
+					authHeader = accessor.getFirstNativeHeader("authorization");
+				}
 
 				if (authHeader == null || authHeader.isBlank()) {
-					log.warn("[WS][CONNECT][차단] Authorization 헤더가 없음. sessionId={}", sessionId);
+					log.warn("[WS][CONNECT][차단] Authorization 헤더 없음. sessionId={}", sessionId);
 					throw new BusinessException(JwtErrorCode.MISSING_TOKEN);
 				}
 
 				String token = extractBearerToken(authHeader);
-
-				// 토큰 길이만 로그 (내용 X)
-				log.info("[WS][CONNECT] Bearer 토큰 추출 완료. tokenLength={}, sessionId={}",
-					(token != null ? token.length() : -1), sessionId
-				);
-
 				Claims claims = jwtTokenValidator.validateAndGetClaims(token, JwtPurpose.ACCESS);
-				log.info("[WS][CONNECT] 토큰 검증 성공. claimsSubject={}, sessionId={}",
-					(claims != null ? claims.getSubject() : "null"), sessionId
-				);
-
 				Authentication authentication = jwtTokenProvider.getAuthentication(claims);
-				log.info("[WS][CONNECT] Authentication 생성 성공. username={}, sessionId={}",
-					authentication.getName(), sessionId
-				);
 
 				accessor.setUser(authentication);
 
 				Map<String, Object> attrs = accessor.getSessionAttributes();
-				if (attrs != null) {
-					attrs.put("wsUsername", authentication.getName());
-				}
+				if (attrs != null) attrs.put("wsUsername", authentication.getName());
 
-				log.info("[WS][CONNECT] STOMP 세션 사용자 설정 완료. username={}, sessionId={}",
-					authentication.getName(), sessionId
-				);
+				log.info("[WS][CONNECT] 인증 완료. username={}, sessionId={}", authentication.getName(), sessionId);
+
+				return org.springframework.messaging.support.MessageBuilder
+					.createMessage(message.getPayload(), accessor.getMessageHeaders());
 			}
 
-			// ===== 2) CONNECT 이후 프레임(SUBSCRIBE/SEND 등) 인증 확인 =====
 			if (command != null && command != StompCommand.CONNECT) {
 				if (accessor.getUser() == null) {
-					// 여기 걸리면: "CONNECT 때 setUser가 안 됐거나",
-					// "클라이언트가 CONNECT 없이 바로 SEND/SUBSCRIBE를 보냈거나",
-					// "프레임이 다른 세션으로 들어왔거나" 중 하나
-					log.warn("[WS][차단] STOMP {} 거부: 사용자 정보 없음(인증 안 됨). sessionId={}, destination={}",
-						command, sessionId, destination
-					);
+					log.warn("[WS][차단] {} 거부: 사용자 정보 없음. sessionId={}, destination={}",
+						command, sessionId, destination);
 					throw new BusinessException(JwtErrorCode.UNAUTHORIZED);
 				}
-
-				log.info("[WS][통과] STOMP {} 인증된 사용자 확인. username={}, sessionId={}, destination={}",
-					command, accessor.getUser().getName(), sessionId, destination
-				);
 			}
+
+			// (추천) SUBSCRIBE destination 권한 체크는 여기 추가
+			// if (command == StompCommand.SUBSCRIBE) { ... }
 
 			return message;
 
 		} catch (BusinessException e) {
-			// 비즈니스 예외는 왜 막혔는지 명확히 로그
-			log.warn("[WS][예외] STOMP 처리 중 차단됨. command={}, sessionId={}, destination={}, errorCode={}",
-				command, sessionId, destination, e.getErrorCode()
-			);
-			throw e;
-		} catch (Exception e) {
-			// 예상치 못한 예외
-			log.error("[WS][예외] STOMP 처리 중 알 수 없는 오류. command={}, sessionId={}, destination={}",
-				command, sessionId, destination, e
-			);
+			log.warn("[WS][예외] 차단됨. command={}, sessionId={}, destination={}, errorCode={}",
+				command, sessionId, destination, e.getErrorCode());
 			throw e;
 		}
 	}
+
 
 	public String extractBearerToken(String authHeader) {
 		String prefix = "Bearer ";

--- a/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
@@ -60,6 +60,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				//인증 없이 누구나 접근 가능한 URL 패턴
 				.requestMatchers(
+					"/ws/**",
+					"/ws",
 					"/api/signup/**",
 					"/api/auth/login",
 					"/api/auth/refresh",

--- a/src/main/java/com/cotato/itda/global/error/constant/JwtErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/JwtErrorCode.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum JwtErrorCode implements ErrorCode {
 
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.", "JWT_401_UNAUTHORIZED"),
 	// 401 Unauthorized: 인증 실패
+
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 입니다.", "JWT_401_INVALID"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.", "JWT_401_EXPIRED"),
 	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다.", "JWT_401_UNSUPPORTED"),
@@ -18,8 +20,8 @@ public enum JwtErrorCode implements ErrorCode {
 	TOKEN_ALG_MISMATCH(HttpStatus.UNAUTHORIZED, "토큰 알고리즘이 일치하지 않습니다.", "JWT_401_ALG_MISMATCH"),
 	TOKEN_PURPOSE_MISMATCH(HttpStatus.UNAUTHORIZED, "토큰 목적이 일치하지 않습니다.", "JWT_401_PURPOSE_MISMATCH"),
 	// 400 Bad Request or 401: 토큰 누락
-	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "헤더에 토큰이 존재하지 않거나 형식이 잘못되었습니다.", "JWT_401_TOKEN_NOT_FOUND");
-
+	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "헤더에 토큰이 존재하지 않거나 형식이 잘못되었습니다.", "JWT_401_TOKEN_NOT_FOUND"),
+	MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.", "JWT_401_MISSING_TOKEN");
 	private final HttpStatus httpStatus;
 	private final String message;
 	private final String code;

--- a/src/main/java/com/cotato/itda/global/security/jwt/key/JwtKeyProvider.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/key/JwtKeyProvider.java
@@ -76,7 +76,6 @@ public class JwtKeyProvider {
 	 * @param purpose : 어떤 목적의 키를 만드는지
 	 */
 	private SecretKey build(String base64, JwtPurpose purpose) {
-		System.out.println(base64);
 		// secret이 설정 파일/환경변수에 제대로 존재하는지 1차 검증
 		if (base64 == null || base64.isBlank()) {
 			throw new IllegalArgumentException(purpose + " JWT 비밀키가 설정 파일에 존재하지 않습니다.");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -68,3 +68,14 @@ jwt:
     algorithm: HS256
     secret-key: ${JWT_REFRESH_SECRET_BASE64}
     validity-in-seconds: 1209600 #14일
+
+security:
+  jwt:
+    secret: ${SPRING_SECURITY_JWT_SECRET}
+app:
+  websocket:
+    allowed-origins: http://localhost:5173,http://localhost:8080, ${FRONTEND_URL}
+
+logging:
+  level:
+    org.springframework.messaging: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -61,3 +61,10 @@ jwt:
     algorithm: HS256
     secret-key: ${JWT_REFRESH_SECRET_BASE64}
     validity-in-seconds: 1209600 #14일
+
+security:
+  jwt:
+    secret: ${SPRING_SECURITY_JWT_SECRET}
+app:
+  websocket:
+    allowed-origins: http://localhost:5173,http://localhost:8080, ${FRONTEND_URL}


### PR DESCRIPTION
# WebSocket + STOMP (JWT 인증) 초기 도입 PR

## #️⃣연관된 이슈
- close #49 

notion.so/Websocket-stomp-2f763c6cda6280739d84cae2efc05cb4?source=copy_link

## 📝작업 내용
- WebSocket + STOMP 기반의 실시간 통신 인프라를 초기 도입했습니다.
- STOMP CONNECT 단계에서 JWT(Access) 인증을 수행하여 세션에 Principal을 설정하고, `/user/queue/**` 개인 큐 라우팅이 가능하도록 구성했습니다.
- 연결 확인을 위한 `/app/connection/ack` 엔드포인트를 추가하고, 개인 큐(`/user/queue/connection/ack`)로 ACK payload를 전송하도록 구현했습니다.
- WebSocket 메시지 처리 중 발생하는 예외를 `/user/queue/errors`로 내려주는 전역 메시징 예외 처리기를 추가했습니다.
- 핸드셰이크 단계에서 clientIp / userAgent를 세션 attributes에 저장하고, connect/subscribe/disconnect 이벤트 로그를 남기도록 했습니다.
- 로컬/운영 환경에서 허용 Origin 및 메시징 로그 레벨 설정을 추가했습니다.

## 🛠️주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [x] 문서 업데이트
- [x] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [x] 의존성 추가/삭제

## ✅리뷰어 확인 포인트
- STOMP 인증 처리 전략
  - 현재는 CONNECT 프레임에서만 JWT 검증 후 `accessor.setUser(authentication)`로 세션을 확정하고,
    이후 SUBSCRIBE/SEND 등에서는 `accessor.getUser()==null`이면 차단하는 방식입니다.
  - 토큰 만료/재발급 시 처리 전략(재CONNECT 유도 vs 서버측 재검증) 의견 부탁드립니다.
- Principal 식별자 형태
  - 현재 `principal.getName()` 값이 `JwtPrincipal[...]` 문자열 형태로 내려올 수 있습니다.
  - 프론트에서 사용하기 좋은 `memberId` 등으로 정규화할지 의견 부탁드립니다.

## 🧪테스트 방법 (서버 재현 가능)
아래는 브라우저 콘솔에서 Raw STOMP 프레임으로 동작을 검증하는 재현 절차입니다.  
(정상이라면 `CONNECTED` 수신 후, `/user/queue/connection/ack`로 `MESSAGE`가 도착합니다.)

### 1) WebSocket 연결 + STOMP CONNECT
```
javascript
const TOKEN = "YOUR_ACCESS_TOKEN"; // Access Token으로 교체
const ws = new WebSocket("ws://localhost:8080/ws", ["v12.stomp"]);

ws.onopen = () => {
  console.log("✅ WS opened");

  ws.send(
    "CONNECT\n" +
    "accept-version:1.2\n" +
    "heart-beat:10000,10000\n" +
    "Authorization:Bearer " + TOKEN + "\n" +
    "\n" +
    "\u0000"
  );
  console.log("➡️ CONNECT sent");
};

ws.onmessage = (e) => {
  console.log("⬅️", e.data);

  // CONNECTED 수신 이후에만 SUBSCRIBE/SEND 수행
  if (typeof e.data === "string" && e.data.startsWith("CONNECTED")) {
    console.log("✅ STOMP CONNECTED received");

    // 에러 채널(권장)
    ws.send("SUBSCRIBE\nid:sub-error\ndestination:/user/queue/errors\n\n\u0000");

    // ACK 채널
    ws.send("SUBSCRIBE\nid:sub-ack\ndestination:/user/queue/connection/ack\n\n\u0000");

    // 컨트롤러 호출
    ws.send(
      "SEND\n" +
      "destination:/app/connection/ack\n" +
      "content-type:application/json\n" +
      "\n" +
      JSON.stringify({ message: "안녕하세요요" }) +
      "\u0000"
    );
  }
};

ws.onclose = (e) => console.log("❌ WS closed", e.code, e.reason);
ws.onerror = (e) => console.log("❌ WS error", e);
```
### 2) 기대 결과 (클라이언트)
- `CONNECTED ...` 프레임 수신
- 이후 `MESSAGE destination:/user/queue/connection/ack ...` 프레임 수신
- payload: `ConnectionAckPayload`

### 3) 기대 결과 (서버)
- `StompAuthChannelInterceptor.preSend()`에서 CONNECT 프레임 로그 확인
- `ConnectionController.ack(...)` 호출 로그 확인
- `WebSocketSessionEventListener`에서 CONNECT/SUBSCRIBE/DISCONNECT 이벤트 로그 확인(로깅 레벨에 따라 다를 수 있음)
