### PR TITLE
[fix] 스웨거 문서 설정 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipController.java
@@ -59,7 +59,7 @@ public class FriendshipController implements FriendshipControllerDocs {
     @Override
     public ApiResponse<FriendshipResDTO.FriendshipListDTO> getFriendshipList(
             @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
-            @RequestParam(required = false) List<FriendshipStatus> status,
+            @RequestParam(required = false, defaultValue = "ACTIVE") List<FriendshipStatus> status,
             @SortDefault(sort = "lastInteractedAt", direction = Sort.Direction.DESC) Sort sort
     ) {
         Long memberId = jwtPrincipal.memberId();

--- a/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipControllerDocs.java
@@ -7,10 +7,12 @@ import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.Explode;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
@@ -69,14 +71,15 @@ public interface FriendshipControllerDocs {
 
             @Parameter(
                     description = "친구 설정 상태. 친구를 설정했다면 ACTIVE로, 설정하지 않았다면 PENDING으로 조회됩니다. 미입력 시 ACTIVE만 조회됩니다.",
-                    example = "ACTIVE",
+                    explode = Explode.TRUE,
                     array = @ArraySchema(schema = @Schema(implementation = FriendshipStatus.class))
             )
-            @RequestParam(required = false) List<FriendshipStatus> status,
+            @RequestParam(required = false, defaultValue = "ACTIVE") List<FriendshipStatus> status,
 
+            @ParameterObject
             @Parameter(
-                    description = "정렬 기준. 예: lastInteractedAt,desc 또는 createdAt,asc",
-                    example = "lastInteractedAt,desc"
+                    name = "sort",
+                    description = "정렬 기준. 예: lastInteractedAt,desc 또는 createdAt,asc"
             )
             Sort sort
     );


### PR DESCRIPTION
## #️⃣연관된 이슈

#54 

## 📝작업 내용

- 친구 목록 조회 API 스웨거 설정 수정
  - 기존 스웨거 문서에서는 sort를 아래와 같은 형식으로 받아야했음
```json
{
  "lastInteractedAt": "desc"
}
```
  - `lastInteractedAt,desc`로 받을 수 있게 수정

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 
<img width="949" height="479" alt="image" src="https://github.com/user-attachments/assets/2615ff5f-b47e-47b9-90bf-23079965bd4d" />


## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
