### PR TITLE
[Feat] 정원 도메인 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ out/
 
 ### QueryDSL ###
 src/main/generated
+
+/GEMINI.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/src/main/java/com/cotato/itda/domain/challenge/service/validator/ChallengeAccessValidator.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/validator/ChallengeAccessValidator.java
@@ -21,7 +21,7 @@ public class ChallengeAccessValidator {
         if (memberId.equals(writerId)) {
             return;
         }
-        boolean isFriend = friendshipRepository.existsByMemberIdAndFriendIdAndStatus(memberId, writerId, FriendshipStatus.ACTIVE);
+        boolean isFriend = friendshipRepository.existsByMember_IdAndFriend_IdAndStatus(memberId, writerId, FriendshipStatus.ACTIVE);
 
         if (!isFriend) {
             throw new BusinessException(ChallengeErrorCode.CHALLENGE_FORBIDDEN);

--- a/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
@@ -57,7 +57,7 @@ public class DiaryQueryService {
             nickname = writer.getName();
         } else {
             // 작성자가 친구 관계인지 확인
-            Friendship friendship = friendshipRepository.findByMemberIdAndFriendIdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
+            Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
                     .orElseThrow(() -> new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN));
 
             nickname = friendship.getDisplayName();
@@ -138,7 +138,7 @@ public class DiaryQueryService {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", targetMemberId)));
 
         // 친구 관계 조회
-        Friendship friendship = friendshipRepository.findByMemberIdAndFriendIdAndStatus(memberId, targetMemberId, FriendshipStatus.ACTIVE)
+        Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, targetMemberId, FriendshipStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN));
 
         // 작성자 정보 변환

--- a/src/main/java/com/cotato/itda/domain/diary/validator/DiaryAccessValidator.java
+++ b/src/main/java/com/cotato/itda/domain/diary/validator/DiaryAccessValidator.java
@@ -18,7 +18,7 @@ public class DiaryAccessValidator {
     public void validateDiaryAccess(Long memberId, Diary diary) {
 
         boolean isMyDiary = memberId.equals(diary.getMember().getId());
-        boolean isFriend = friendshipRepository.existsByMemberIdAndFriendIdAndStatus(memberId, diary.getMember().getId(), FriendshipStatus.ACTIVE);
+        boolean isFriend = friendshipRepository.existsByMember_IdAndFriend_IdAndStatus(memberId, diary.getMember().getId(), FriendshipStatus.ACTIVE);
 
         if (!isMyDiary && !isFriend) {
             throw new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN);

--- a/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/controller/FriendshipController.java
@@ -28,7 +28,6 @@ public class FriendshipController implements FriendshipControllerDocs {
     private final FriendshipCommandService friendshipCommandService;
     private final FriendshipQueryService friendshipQueryService;
 
-    // TODO: JWT 사용 시 memberId 추출 로직으로 변경
     @SecurityRequirement(name = "AccessToken")
     @PostMapping("/{friendId}")
     @Override
@@ -40,7 +39,6 @@ public class FriendshipController implements FriendshipControllerDocs {
         return ApiResponse.success(friendshipCommandService.createFriendship(friendId, memberId));
     }
 
-    // TODO: JWT 사용 시 memberId 추출 로직으로 변경
     @SecurityRequirement(name = "AccessToken")
     @PatchMapping("/{friendshipId}")
     @Override
@@ -53,7 +51,6 @@ public class FriendshipController implements FriendshipControllerDocs {
         return ApiResponse.success(friendshipCommandService.updateFriendship(dto, friendshipId, memberId));
     }
 
-    // TODO: JWT 사용 시 memberId 추출 로직으로 변경
     @SecurityRequirement(name = "AccessToken")
     @GetMapping
     @Override
@@ -66,7 +63,6 @@ public class FriendshipController implements FriendshipControllerDocs {
         return ApiResponse.success(friendshipQueryService.getFriendshipList(memberId, status, sort));
     }
 
-    // TODO: JWT 사용 시 memberId 추출 로직으로 변경
     @SecurityRequirement(name = "AccessToken")
     @DeleteMapping("/{friendshipId}")
     @Override
@@ -79,7 +75,6 @@ public class FriendshipController implements FriendshipControllerDocs {
         return ApiResponse.success(null);
     }
 
-    // TODO: JWT 사용 시 memberId 추출 로직으로 변경
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/settings/{friendshipId}")
     @Override

--- a/src/main/java/com/cotato/itda/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/entity/Friendship.java
@@ -56,12 +56,19 @@ public class Friendship extends BaseEntity {
 
     public void update(String nickname, SpeechStyle speechStyle, String chatGoal, FriendshipStatus status) {
         this.nickname = nickname;
-        if (speechStyle != null) this.speechStyle = speechStyle;
-        if (chatGoal != null) this.chatGoal = chatGoal;
-        if (status != null) this.status = status;
+        if (speechStyle != null)
+            this.speechStyle = speechStyle;
+        if (chatGoal != null)
+            this.chatGoal = chatGoal;
+        if (status != null)
+            this.status = status;
     }
 
     public String getDisplayName() {
         return nickname != null ? nickname : friend.getName();
+    }
+
+    public Long getFriendId() {
+        return friend.getId();
     }
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/exception/code/FriendshipErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/exception/code/FriendshipErrorCode.java
@@ -9,37 +9,37 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FriendshipErrorCode implements ErrorCode {
 
-    NOT_FOUND(
-            HttpStatus.NOT_FOUND,
-            "FRIENDSHIP_ERROR_404_NOT_FOUND",
-            "친구 관계를 찾을 수 없습니다."),
+        NOT_FOUND(
+                        HttpStatus.NOT_FOUND,
+                        "FRIENDSHIP_ERROR_404_NOT_FOUND",
+                        "친구 관계를 찾을 수 없습니다."),
 
-    INVALID_SPEECH_STYLE(
-            HttpStatus.BAD_REQUEST,
-            "FRIENDSHIP_ERROR_400_INVALID_SPEECH_STYLE",
-            "유효하지 않은 대화 말투입니다."
-    ),
+        INVALID_SPEECH_STYLE(
+                        HttpStatus.BAD_REQUEST,
+                        "FRIENDSHIP_ERROR_400_INVALID_SPEECH_STYLE",
+                        "유효하지 않은 대화 말투입니다."),
 
-    CANNOT_ADD_SELF(
-            HttpStatus.BAD_REQUEST,
-            "FRIENDSHIP_ERROR_400_CANNOT_ADD_SELF",
-            "자기 자신을 친구로 추가할 수 없습니다."
-    ),
+        CANNOT_ADD_SELF(
+                        HttpStatus.BAD_REQUEST,
+                        "FRIENDSHIP_ERROR_400_CANNOT_ADD_SELF",
+                        "자기 자신을 친구로 추가할 수 없습니다."),
 
-    FRIENDSHIP_ALREADY_EXISTS(
-            HttpStatus.BAD_REQUEST,
-            "FRIENDSHIP_ERROR_400_FRIENDSHIP_ALREADY_EXISTS",
-            "이미 존재하는 친구 관계입니다."
-    ),
+        FRIENDSHIP_ALREADY_EXISTS(
+                        HttpStatus.BAD_REQUEST,
+                        "FRIENDSHIP_ERROR_400_FRIENDSHIP_ALREADY_EXISTS",
+                        "이미 존재하는 친구 관계입니다."),
 
-    FORBIDDEN(
-            HttpStatus.FORBIDDEN,
-            "FRIENDSHIP_ERROR_403_FORBIDDEN",
-            "권한이 없는 친구 관계입니다."
-    ),
-    ;
+        FORBIDDEN(
+                        HttpStatus.FORBIDDEN,
+                        "FRIENDSHIP_ERROR_403_FORBIDDEN",
+                        "권한이 없는 친구 관계입니다."),
+        NOT_ACTIVE(
+                        HttpStatus.BAD_REQUEST,
+                        "FRIENDSHIP_ERROR_400_NOT_ACTIVE",
+                        "활성 상태인 친구 관계가 아닙니다."),
+                        ;
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
@@ -14,12 +14,12 @@ import java.util.Optional;
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findAllByMemberIdAndStatusIn(Long memberId, List<FriendshipStatus> statuses, Sort sort);
 
-    boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+    boolean existsByMember_IdAndFriend_Id(Long memberId, Long friendId);
 
-    boolean existsByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
+    boolean existsByMember_IdAndFriend_IdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
 
     Optional<Friendship> findByMemberAndFriendAndStatus(Member member, Member friend, FriendshipStatus friendshipStatus);
-    Optional<Friendship> findByMemberIdAndFriendIdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
+    Optional<Friendship> findByMember_IdAndFriend_IdAndStatus(Long memberId, Long friendId, FriendshipStatus status);
 
     @Query("SELECT f FROM Friendship f " +
             "JOIN FETCH f.friend " +
@@ -31,6 +31,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Sort sort);
 
-    List<Friendship> findAllByMemberIdAndFriendIdInAndStatus(Long memberId, List<Long> friendIds,
+    List<Friendship> findAllByMember_IdAndFriend_IdInAndStatus(Long memberId, List<Long> friendIds,
             FriendshipStatus status);
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
@@ -28,12 +28,9 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             "AND f.status = 'ACTIVE'")
     List<Friendship> findActiveFriendships(@Param("memberId") Long memberId,
                                            @Param("friendIds") List<Long> friendIds);
-    List<Friendship> findAllByMember_IdAndStatus(Long memberId, FriendshipStatus status, Sort sort);
 
-    List<Friendship> findAllByMember_IdAndFriend_IdInAndStatus(Long memberId, List<Long> friendIds,
+    List<Friendship> findAllByMemberIdAndStatus(Long memberId, FriendshipStatus status, Sort sort);
+
+    List<Friendship> findAllByMemberIdAndFriendIdInAndStatus(Long memberId, List<Long> friendIds,
             FriendshipStatus status);
-
-    boolean existsByMember_IdAndFriend_Id(Long memberId, Long friendId);
-
-    Optional<Friendship> findByMember_IdAndFriend_Id(Long memberId, Long friendId);
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/repository/FriendshipRepository.java
@@ -7,9 +7,17 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findAllByMemberIdAndStatusIn(Long memberId, List<FriendshipStatus> statuses, Sort sort);
 
-    boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+    List<Friendship> findAllByMember_IdAndStatus(Long memberId, FriendshipStatus status, Sort sort);
+
+    List<Friendship> findAllByMember_IdAndFriend_IdInAndStatus(Long memberId, List<Long> friendIds,
+            FriendshipStatus status);
+
+    boolean existsByMember_IdAndFriend_Id(Long memberId, Long friendId);
+
+    Optional<Friendship> findByMember_IdAndFriend_Id(Long memberId, Long friendId);
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
@@ -32,138 +32,141 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class FriendshipCommandServiceImpl implements FriendshipCommandService {
 
-    private final FriendshipRepository friendshipRepository;
-    private final MemberRepository memberRepository;
-    private final ChatTopicRepository chatTopicRepository;
-    private final FriendshipTopicRepository friendshipTopicRepository;
+        private final FriendshipRepository friendshipRepository;
+        private final MemberRepository memberRepository;
+        private final ChatTopicRepository chatTopicRepository;
+        private final FriendshipTopicRepository friendshipTopicRepository;
 
-    @Transactional
-    @Override
-    public FriendshipResDTO.CreateDTO createFriendship(Long friendId, Long memberId) {
+        @Transactional
+        @Override
+        public FriendshipResDTO.CreateDTO createFriendship(Long friendId, Long memberId) {
 
-        if (memberId.equals(friendId)) {
-            throw new FriendshipException(
-                    FriendshipErrorCode.CANNOT_ADD_SELF
-            );
+                if (memberId.equals(friendId)) {
+                        throw new FriendshipException(
+                                        FriendshipErrorCode.CANNOT_ADD_SELF);
+                }
+
+                if (friendshipRepository.existsByMember_IdAndFriend_Id(memberId, friendId)) {
+                        throw new FriendshipException(
+                                        FriendshipErrorCode.FRIENDSHIP_ALREADY_EXISTS);
+                }
+
+                Member member = memberRepository.findById(memberId)
+                                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND,
+                                                Map.of("userId", memberId)));
+
+                Member friend = memberRepository.findById(friendId)
+                                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND,
+                                                Map.of("friendId", friendId)));
+
+                Friendship friendship = FriendshipConverter.toFriendship(member, friend);
+
+                Friendship savedFriendship = friendshipRepository.save(friendship);
+
+                return FriendshipConverter.toCreateDTO(savedFriendship);
         }
 
-        if (friendshipRepository.existsByMemberIdAndFriendId(memberId, friendId)) {
-            throw new FriendshipException(
-                    FriendshipErrorCode.FRIENDSHIP_ALREADY_EXISTS
-            );
+        @Transactional
+        @Override
+        public FriendshipResDTO.UpdateDTO updateFriendship(FriendshipReqDTO.UpdateDTO dto, Long friendshipId,
+                        Long memberId) {
+
+                Friendship friendship = friendshipRepository.findById(friendshipId)
+                                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND,
+                                                Map.of("friendshipId", friendshipId)));
+
+                // 본인의 친구 관계인지 확인
+                if (!friendship.getMember().getId().equals(memberId)) {
+                        throw new FriendshipException(FriendshipErrorCode.FORBIDDEN,
+                                        Map.of("friendshipId", friendshipId, "memberId", memberId));
+                }
+
+                friendship.update(dto.nickname(), dto.speechStyle(), dto.chatGoal(), FriendshipStatus.ACTIVE);
+
+                updateFriendshipTopics(friendship, dto.topicCodes());
+
+                return FriendshipConverter.toUpdateDTO(friendship);
         }
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", memberId)));
+        private void updateFriendshipTopics(Friendship friendship, List<String> topicCodes) {
+                // 1. 요청한 주제 검증 및 조회
+                List<ChatTopic> requestedTopics = validateAndFetchTopics(topicCodes);
 
-        Member friend = memberRepository.findById(friendId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, Map.of("friendId", friendId)));
+                // 2. 기존 주제 조회
+                List<FriendshipTopic> existingTopics = friendship.getFriendshipTopics();
 
-        Friendship friendship = FriendshipConverter.toFriendship(member, friend);
-
-        Friendship savedFriendship = friendshipRepository.save(friendship);
-
-        return FriendshipConverter.toCreateDTO(savedFriendship);
-    }
-
-    @Transactional
-    @Override
-    public FriendshipResDTO.UpdateDTO updateFriendship(FriendshipReqDTO.UpdateDTO dto, Long friendshipId, Long memberId) {
-
-        Friendship friendship = friendshipRepository.findById(friendshipId)
-                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND, Map.of("friendshipId", friendshipId)));
-
-        // 본인의 친구 관계인지 확인
-        if (!friendship.getMember().getId().equals(memberId)) {
-            throw new FriendshipException(FriendshipErrorCode.FORBIDDEN, Map.of("friendshipId", friendshipId, "memberId", memberId));
+                // 3. 변경분 계산 및 처리
+                updateTopicChanges(friendship, requestedTopics, existingTopics);
         }
 
-        friendship.update(dto.nickname(), dto.speechStyle(), dto.chatGoal(), FriendshipStatus.ACTIVE);
+        private List<ChatTopic> validateAndFetchTopics(List<String> topicCodes) {
+                List<ChatTopic> topics = chatTopicRepository.findAllByCodeIn(topicCodes);
 
-        updateFriendshipTopics(friendship, dto.topicCodes());
+                Set<String> foundCodes = topics.stream()
+                                .map(ChatTopic::getCode)
+                                .collect(Collectors.toSet());
 
-        return FriendshipConverter.toUpdateDTO(friendship);
-    }
+                List<String> notFoundCodes = topicCodes.stream()
+                                .filter(code -> !foundCodes.contains(code))
+                                .toList();
 
-    private void updateFriendshipTopics(Friendship friendship, List<String> topicCodes) {
-        // 1. 요청한 주제 검증 및 조회
-        List<ChatTopic> requestedTopics = validateAndFetchTopics(topicCodes);
+                if (!notFoundCodes.isEmpty()) {
+                        throw new ChatTopicException(
+                                        ChatTopicErrorCode.BAD_REQUEST,
+                                        Map.of("notFoundCodes", notFoundCodes, "requestedCodes", topicCodes));
+                }
 
-        // 2. 기존 주제 조회
-        List<FriendshipTopic> existingTopics = friendship.getFriendshipTopics();
-
-        // 3. 변경분 계산 및 처리
-        updateTopicChanges(friendship, requestedTopics, existingTopics);
-    }
-
-    private List<ChatTopic> validateAndFetchTopics(List<String> topicCodes) {
-        List<ChatTopic> topics = chatTopicRepository.findAllByCodeIn(topicCodes);
-
-        Set<String> foundCodes = topics.stream()
-                .map(ChatTopic::getCode)
-                .collect(Collectors.toSet());
-
-        List<String> notFoundCodes = topicCodes.stream()
-                .filter(code -> !foundCodes.contains(code))
-                .toList();
-
-        if (!notFoundCodes.isEmpty()) {
-            throw new ChatTopicException(
-                    ChatTopicErrorCode.BAD_REQUEST,
-                    Map.of("notFoundCodes", notFoundCodes, "requestedCodes", topicCodes)
-            );
+                return topics;
         }
 
-        return topics;
-    }
+        private void updateTopicChanges(
+                        Friendship friendship,
+                        List<ChatTopic> requestedTopics,
+                        List<FriendshipTopic> existingTopics) {
+                Set<String> requestedCodes = requestedTopics.stream()
+                                .map(ChatTopic::getCode)
+                                .collect(Collectors.toSet());
 
-    private void updateTopicChanges(
-            Friendship friendship,
-            List<ChatTopic> requestedTopics,
-            List<FriendshipTopic> existingTopics
-    ) {
-        Set<String> requestedCodes = requestedTopics.stream()
-                .map(ChatTopic::getCode)
-                .collect(Collectors.toSet());
+                Set<String> existingCodes = existingTopics.stream()
+                                .map(ft -> ft.getChatTopic().getCode())
+                                .collect(Collectors.toSet());
 
-        Set<String> existingCodes = existingTopics.stream()
-                .map(ft -> ft.getChatTopic().getCode())
-                .collect(Collectors.toSet());
+                // 삭제할 항목 (기존에 있었는데 요청에 없는 것)
+                List<FriendshipTopic> topicsToDelete = existingTopics.stream()
+                                .filter(ft -> !requestedCodes.contains(ft.getChatTopic().getCode()))
+                                .toList();
 
-        // 삭제할 항목 (기존에 있었는데 요청에 없는 것)
-        List<FriendshipTopic> topicsToDelete = existingTopics.stream()
-                .filter(ft -> !requestedCodes.contains(ft.getChatTopic().getCode()))
-                .toList();
+                // 추가할 항목 (요청에 있는데 기존에 없는 것)
+                List<FriendshipTopic> topicsToAdd = requestedTopics.stream()
+                                .filter(topic -> !existingCodes.contains(topic.getCode()))
+                                .map(topic -> FriendshipTopic.builder()
+                                                .friendship(friendship)
+                                                .chatTopic(topic)
+                                                .build())
+                                .toList();
 
-        // 추가할 항목 (요청에 있는데 기존에 없는 것)
-        List<FriendshipTopic> topicsToAdd = requestedTopics.stream()
-                .filter(topic -> !existingCodes.contains(topic.getCode()))
-                .map(topic -> FriendshipTopic.builder()
-                        .friendship(friendship)
-                        .chatTopic(topic)
-                        .build())
-                .toList();
-
-        // 저장
-        if (!topicsToDelete.isEmpty()) {
-            friendshipTopicRepository.deleteAll(topicsToDelete);
-        }
-        if (!topicsToAdd.isEmpty()) {
-            friendshipTopicRepository.saveAll(topicsToAdd);
-        }
-    }
-
-    @Override
-    @Transactional
-    public void deleteFriendship(Long friendshipId, Long memberId) {
-        Friendship friendship = friendshipRepository.findById(friendshipId)
-                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND, Map.of("friendshipId", friendshipId)));
-
-        // 본인의 친구 관계인지 확인
-        if (!friendship.getMember().getId().equals(memberId)) {
-            throw new FriendshipException(FriendshipErrorCode.FORBIDDEN, Map.of("friendshipId", friendshipId, "memberId", memberId));
+                // 저장
+                if (!topicsToDelete.isEmpty()) {
+                        friendshipTopicRepository.deleteAll(topicsToDelete);
+                }
+                if (!topicsToAdd.isEmpty()) {
+                        friendshipTopicRepository.saveAll(topicsToAdd);
+                }
         }
 
-        friendshipRepository.delete(friendship);
-    }
+        @Override
+        @Transactional
+        public void deleteFriendship(Long friendshipId, Long memberId) {
+                Friendship friendship = friendshipRepository.findById(friendshipId)
+                                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND,
+                                                Map.of("friendshipId", friendshipId)));
+
+                // 본인의 친구 관계인지 확인
+                if (!friendship.getMember().getId().equals(memberId)) {
+                        throw new FriendshipException(FriendshipErrorCode.FORBIDDEN,
+                                        Map.of("friendshipId", friendshipId, "memberId", memberId));
+                }
+
+                friendshipRepository.delete(friendship);
+        }
 }

--- a/src/main/java/com/cotato/itda/domain/friendship/service/query/FriendshipQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/service/query/FriendshipQueryServiceImpl.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 
+import com.cotato.itda.domain.member.entity.MemberStatus;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,8 +32,7 @@ public class FriendshipQueryServiceImpl implements FriendshipQueryService {
     public FriendshipResDTO.FriendshipListDTO getFriendshipList(
             Long memberId,
             List<FriendshipStatus> statuses,
-            Sort sort
-    ) {
+            Sort sort) {
         if (!memberRepository.existsById(memberId)) {
             throw new BusinessException(UserErrorCode.USER_NOT_FOUND,
                     Map.of("memberId", memberId));
@@ -44,17 +45,24 @@ public class FriendshipQueryServiceImpl implements FriendshipQueryService {
         List<Friendship> friendships = friendshipRepository
                 .findAllByMemberIdAndStatusIn(memberId, statuses, sort);
 
-        return FriendshipConverter.toFriendshipListDTO(friendships);
+        // 상대방 친구의 계정 상태가 ACTIVE인 경우만 필터링
+        List<Friendship> filteredFriendships = friendships.stream()
+                .filter(friendship -> friendship.getFriend().getStatus() == MemberStatus.ACTIVE)
+                .toList();
+
+        return FriendshipConverter.toFriendshipListDTO(filteredFriendships);
     }
 
     @Override
     public FriendshipResDTO.FriendshipSettingsDTO getFriendshipSettings(Long friendshipId, Long memberId) {
         Friendship friendship = friendshipRepository.findById(friendshipId)
-                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND, Map.of("friendshipId", friendshipId)));
+                .orElseThrow(() -> new FriendshipException(FriendshipErrorCode.NOT_FOUND,
+                        Map.of("friendshipId", friendshipId)));
 
         // 본인의 친구 관계인지 확인
         if (!friendship.getMember().getId().equals(memberId)) {
-            throw new FriendshipException(FriendshipErrorCode.FORBIDDEN, Map.of("friendshipId", friendshipId, "memberId", memberId));
+            throw new FriendshipException(FriendshipErrorCode.FORBIDDEN,
+                    Map.of("friendshipId", friendshipId, "memberId", memberId));
         }
 
         return FriendshipConverter.toFriendshipSettingsDTO(friendship);

--- a/src/main/java/com/cotato/itda/domain/garden/controller/PlantController.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/PlantController.java
@@ -1,0 +1,42 @@
+package com.cotato.itda.domain.garden.controller;
+
+import com.cotato.itda.domain.garden.dto.req.PlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import com.cotato.itda.domain.garden.service.command.PlantCommandService;
+import com.cotato.itda.domain.garden.service.query.PlantQueryService;
+import com.cotato.itda.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plants")
+@Tag(name = "Plant", description = "식물 API")
+public class PlantController implements PlantControllerDocs {
+
+    private final PlantCommandService plantCommandService;
+    private final PlantQueryService plantQueryService;
+
+    // @Override
+    // @PostMapping
+    // public ApiResponse<PlantResDTO.CreatePlantResDTO> createPlant(
+    // @Valid @RequestBody PlantReqDTO.CreatePlantReqDTO dto) {
+    // return ApiResponse.success(plantCommandService.createPlant(dto));
+    // }
+
+    @Override
+    @GetMapping
+    public ApiResponse<PlantResDTO.PlantListResDto> getAllPlants(
+            @SortDefault(sort = "difficulty", direction = Sort.Direction.ASC) Sort sort
+    ) {
+        return ApiResponse.success(plantQueryService.getPlantList(sort));
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/controller/PlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/PlantControllerDocs.java
@@ -1,0 +1,41 @@
+package com.cotato.itda.domain.garden.controller;
+
+import com.cotato.itda.domain.garden.dto.req.PlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import com.cotato.itda.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PlantControllerDocs {
+
+        // @Operation(summary = "식물 추가 API By 정원", description = "새로운 식물을 추가합니다. 관리자 권한이
+        // 필요합니다.")
+        // @ApiResponses({
+        // @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+        // description = "성공"),
+        // @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+        // description = "유효하지 않은 입력값 또는 이미 존재하는 식물 이름"),
+        // @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403",
+        // description = "관리자 권한 없음")
+        // })
+        // @PostMapping
+        // ApiResponse<PlantResDTO.CreatePlantResDTO> createPlant(
+        // @Valid @RequestBody PlantReqDTO.CreatePlantReqDTO dto
+        // );
+
+        @Operation(summary = "전체 식물 조회 API By 정원", description = "전체 식물 목록을 조회합니다. 정렬 조건을 변경할 수 있습니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+        })
+        @GetMapping
+        ApiResponse<PlantResDTO.PlantListResDto> getAllPlants(
+                        @Parameter(description = "정렬 기준 (기본값: difficulty, 오름차순)") @ParameterObject @SortDefault(sort = "difficulty", direction = Sort.Direction.ASC) Sort sort);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
@@ -2,7 +2,9 @@ package com.cotato.itda.domain.garden.controller;
 
 import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
 import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
 import com.cotato.itda.domain.garden.service.command.SharedPlantCommandService;
+import com.cotato.itda.domain.garden.service.query.SharedPlantQueryService;
 import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 import jakarta.validation.Valid;
@@ -10,14 +12,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/shared-plants")
 public class SharedPlantController implements SharedPlantControllerDocs {
 
     private final SharedPlantCommandService sharedPlantCommandService;
+    private final SharedPlantQueryService sharedPlantQueryService;
 
-    // TODO: 식물 시듦 상태 변환 & 식물 함께 돌봄으로 변환
+    // TODO: 식물 시듦 상태 변환 & 식물 함께 돌봄으로 변환 & 솔로 모드 자동 진입
+
+    @GetMapping
+    public ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getSharedPlants(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @RequestParam(name = "status", required = false) List<SharedPlantStatus> statuses
+    ) {
+        List<SharedPlantStatus> effectiveStatuses = (statuses == null || statuses.isEmpty())
+                ? List.of(SharedPlantStatus.GROWING, SharedPlantStatus.WITHERED)
+                : statuses;
+        return ApiResponse.success(sharedPlantQueryService.getSharedPlants(jwtPrincipal.memberId(), effectiveStatuses));
+    }
 
     @PatchMapping("/{sharedPlantId}")
     public ApiResponse<SharedPlantResDTO.WaterInfoResDTO> wateringPlant(

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
@@ -1,0 +1,30 @@
+package com.cotato.itda.domain.garden.controller;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.service.command.SharedPlantCommandService;
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shared-plants")
+public class SharedPlantController implements SharedPlantControllerDocs {
+
+    private final SharedPlantCommandService sharedPlantCommandService;
+
+    // TODO: 식물 시듦 상태 변환 & 식물 함께 돌봄으로 변환
+
+    @PatchMapping("/{sharedPlantId}")
+    public ApiResponse<SharedPlantResDTO.WaterInfoResDTO> wateringPlant(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @PathVariable(name = "sharedPlantId") Long sharedPlantId,
+            @Valid @RequestBody SharedPlantReqDTO.WaterPlantReqDTO dto
+    ) {
+        return ApiResponse.success(sharedPlantCommandService.waterPlant(sharedPlantId, dto, jwtPrincipal.memberId()));
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
@@ -1,0 +1,4 @@
+package com.cotato.itda.domain.garden.controller;
+
+public interface SharedPlantControllerDocs {
+}

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
@@ -1,4 +1,47 @@
 package com.cotato.itda.domain.garden.controller;
 
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
 public interface SharedPlantControllerDocs {
+
+    @Operation(summary = "공유 식물 목록 조회 API By 정원", description = "상태별로 공유 식물 목록을 조회합니다. ?status=GROWING&status=WITHERED 또는 ?status=COMPLETED 형태로 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping
+    ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getSharedPlants(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @Parameter(description = "조회할 상태 목록 (GROWING, WITHERED, COMPLETED)", example = "GROWING")
+            @RequestParam(name = "status") List<SharedPlantStatus> statuses
+    );
+
+    @Operation(summary = "공유 식물 물주기 API By 정원", description = "공유 식물에 물을 줍니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공유 식물을 찾을 수 없음")
+    })
+    @PatchMapping("/{sharedPlantId}")
+    ApiResponse<SharedPlantResDTO.WaterInfoResDTO> wateringPlant(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @Parameter(description = "공유 식물 ID") @PathVariable(name = "sharedPlantId") Long sharedPlantId,
+            @Valid @RequestBody SharedPlantReqDTO.WaterPlantReqDTO dto
+    );
 }

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
@@ -7,6 +7,8 @@ import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,7 +22,7 @@ import java.util.List;
 
 public interface SharedPlantControllerDocs {
 
-    @Operation(summary = "공유 식물 목록 조회 API By 정원", description = "상태별로 공유 식물 목록을 조회합니다. ?status=GROWING&status=WITHERED 또는 ?status=COMPLETED 형태로 조회합니다.")
+    @Operation(summary = "공유 식물 목록 조회 API By 정원", description = "상태별로 공유 식물 목록을 조회합니다. ?status=GROWING&status=WITHERED 또는 ?status=COMPLETED 형태로 조회합니다. status를 지정하지 않으면 기본값으로 GROWING, WITHERED를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
@@ -28,8 +30,11 @@ public interface SharedPlantControllerDocs {
     @GetMapping
     ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getSharedPlants(
             @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
-            @Parameter(description = "조회할 상태 목록 (GROWING, WITHERED, COMPLETED)", example = "GROWING")
-            @RequestParam(name = "status") List<SharedPlantStatus> statuses
+            @Parameter(
+                    description = "조회할 상태 목록 (GROWING, WITHERED, COMPLETED). 미지정 시 기본값: GROWING, WITHERED",
+                    array = @ArraySchema(schema = @Schema(implementation = SharedPlantStatus.class))
+            )
+            @RequestParam(name = "status", required = false) List<SharedPlantStatus> statuses
     );
 
     @Operation(summary = "공유 식물 물주기 API By 정원", description = "공유 식물에 물을 줍니다.")

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantInviteController.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantInviteController.java
@@ -1,0 +1,53 @@
+package com.cotato.itda.domain.garden.controller;
+
+import com.cotato.itda.domain.garden.dto.req.PlantInviteReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+import com.cotato.itda.domain.garden.service.command.SharedPlantInviteCommandService;
+import com.cotato.itda.domain.garden.service.query.SharedPlantInviteQueryService;
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plant-invites")
+public class SharedPlantInviteController implements SharedPlantInviteControllerDocs {
+
+    private final SharedPlantInviteQueryService sharedPlantInviteQueryService;
+    private final SharedPlantInviteCommandService sharedPlantInviteCommandService;
+
+    @Override
+    @GetMapping("/candidates")
+    public ApiResponse<PlantInviteResDTO.PlantInviteCandidatesResDto> getInviteCandidates(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal) {
+        return ApiResponse.success(sharedPlantInviteQueryService.getInviteCandidates(jwtPrincipal.memberId()));
+    }
+
+    @Override
+    @GetMapping("/my")
+    public ApiResponse<PlantInviteResDTO.MyPlantInviteListResDTO> getMyPendingInvitations(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal) {
+        return ApiResponse.success(sharedPlantInviteQueryService.getMyPendingInvitations(jwtPrincipal.memberId()));
+    }
+
+    @Override
+    @PostMapping
+    public ApiResponse<PlantInviteResDTO.CreateSharedPlantInviteResDTO> createInvite(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @Valid @RequestBody PlantInviteReqDTO.CreateSharedPlantInviteReqDTO dto) {
+        return ApiResponse.success(sharedPlantInviteCommandService.createInvite(jwtPrincipal.memberId(), dto));
+    }
+
+    @Override
+    @PatchMapping("/{plantInviteId}")
+    public ApiResponse<PlantInviteResDTO.UpdateSharedPlantInviteResDTO> updateInviteStatus(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @PathVariable(name = "plantInviteId") Long plantInviteId,
+            @Valid @RequestBody PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto) {
+        return ApiResponse.success(
+                sharedPlantInviteCommandService.updateInviteStatus(jwtPrincipal.memberId(), plantInviteId, dto));
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantInviteControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantInviteControllerDocs.java
@@ -1,0 +1,66 @@
+package com.cotato.itda.domain.garden.controller;
+
+import com.cotato.itda.domain.garden.dto.req.PlantInviteReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "PlantInvite", description = "식물 초대 API")
+public interface SharedPlantInviteControllerDocs {
+
+        @Operation(summary = "식물 초대 후보 친구 리스트 조회 API By 정원", description = "식물 키우기에 초대할 수 있는 후보 친구 목록을 조회합니다. (현재 함께 키우는 식물이 없고, 초대 대기 상태도 아닌 친구)")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+        })
+        @SecurityRequirement(name = "AccessToken")
+        @GetMapping("/candidates")
+        ApiResponse<PlantInviteResDTO.PlantInviteCandidatesResDto> getInviteCandidates(
+                        @AuthenticationPrincipal JwtPrincipal jwtPrincipal);
+
+        @Operation(summary = "내 공유 식물 초대 목록 조회 API By 정원", description = "나에게 온 대기 중인(PENDING) 식물 초대 목록을 조회합니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+        })
+        @SecurityRequirement(name = "AccessToken")
+        @GetMapping("/my")
+        ApiResponse<PlantInviteResDTO.MyPlantInviteListResDTO> getMyPendingInvitations(
+                        @AuthenticationPrincipal JwtPrincipal jwtPrincipal);
+
+        @Operation(summary = "식물 초대 요청 API By 정원", description = "친구에게 식물 키우기 초대 요청을 보냅니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "자기 자신 초대 불가능, 이미 대기 소환장 존재, 이미 공유 식물 존재"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 혹은 상대방이 ACTIVE 상태가 아님 (친구 아님)"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 혹은 식물을 찾을 수 없음")
+        })
+        @SecurityRequirement(name = "AccessToken")
+        @PostMapping
+        ApiResponse<PlantInviteResDTO.CreateSharedPlantInviteResDTO> createInvite(
+                        @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+                        @Valid @RequestBody PlantInviteReqDTO.CreateSharedPlantInviteReqDTO dto);
+
+        @Operation(summary = "식물 초대 수락/거절 API By 정원", description = "나에게 온 식물 초대를 수락하거나 거절합니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 처리된 초대장, 이미 키우고 있는 식물 존재, 잘못된 상태값"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "초대받은 본인이 아님"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "초대장을 찾을 수 없음")
+        })
+        @SecurityRequirement(name = "AccessToken")
+        @PatchMapping("/{plantInviteId}")
+        ApiResponse<PlantInviteResDTO.UpdateSharedPlantInviteResDTO> updateInviteStatus(
+                        @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+                        @PathVariable(name = "plantInviteId") Long plantInviteId,
+                        @Valid @RequestBody PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/converter/PlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/PlantConverter.java
@@ -1,0 +1,56 @@
+package com.cotato.itda.domain.garden.converter;
+
+import com.cotato.itda.domain.garden.dto.req.PlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import com.cotato.itda.domain.garden.entity.Plant;
+
+import java.util.List;
+
+public class PlantConverter {
+
+    public static PlantResDTO.CreatePlantResDTO toPlantCreateResDto(Plant plant) {
+        return PlantResDTO.CreatePlantResDTO.builder()
+                .plantId(plant.getId())
+                .plantName(plant.getName())
+                .createdAt(plant.getCreatedAt())
+                .build();
+    }
+
+    public static Plant toPlant(PlantReqDTO.CreatePlantReqDTO dto) {
+        return Plant.builder()
+                .name(dto.name())
+                .difficulty(dto.difficulty())
+                .duration(dto.duration())
+                .hashtags(dto.hashtags())
+                .height(dto.height())
+                .seedMax(dto.seedMax())
+                .sproutMax(dto.sproutMax())
+                .stemMax(dto.stemMax())
+                .budMax(dto.budMax())
+                .bloomMax(dto.bloomMax())
+                .build();
+    }
+
+    public static PlantResDTO.PlantInfoResDto toPlantInfoResDto(Plant plant) {
+        return PlantResDTO.PlantInfoResDto.builder()
+                .plantId(plant.getId())
+                .plantName(plant.getName())
+                .difficulty(plant.getDifficulty())
+                .duration(plant.getDuration())
+                .hashtags(plant.getHashtags())
+                .height(plant.getHeight())
+                .build();
+    }
+
+    public static PlantResDTO.PlantListResDto toPlantListResDto(List<Plant> plants) {
+
+        List<PlantResDTO.PlantInfoResDto> plantInfos = plants.stream()
+                .map(PlantConverter::toPlantInfoResDto)
+                .toList();
+
+        return PlantResDTO.PlantListResDto.builder()
+                .count(plants.size())
+                .plants(plantInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
@@ -1,6 +1,6 @@
 package com.cotato.itda.domain.garden.converter;
 
-import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO.SharedPlantInfoDTO;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
 import com.cotato.itda.domain.garden.entity.SharedPlant;
 import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
 import com.cotato.itda.domain.member.entity.Member;
@@ -26,17 +26,38 @@ public class SharedPlantConverter {
                 .build();
     }
 
-    public static SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant) {
-        return SharedPlantInfoDTO.builder()
+    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant) {
+        return SharedPlantResDTO.SharedPlantInfoDTO.builder()
                 .sharedPlantId(sharedPlant.getId())
                 .memberAId(sharedPlant.getMemberA().getId())
                 .memberBId(sharedPlant.getMemberB().getId())
                 .plantId(sharedPlant.getPlant().getId())
                 .nickname(sharedPlant.getNickname())
                 .growthValue(sharedPlant.getGrowthValue())
-                .growthStage(sharedPlant.getGrowthStage().name())
-                .status(sharedPlant.getStatus().name())
+                .growthStage(sharedPlant.getGrowthStage())
+                .status(sharedPlant.getStatus())
                 .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+
+    public static SharedPlantResDTO.LastWateredByDTO toLastWateredByDTO(Member member) {
+        return SharedPlantResDTO.LastWateredByDTO.builder()
+                .memberId(member.getId())
+                .isMe(true)
+                .build();
+    }
+
+    public static SharedPlantResDTO.WaterInfoResDTO toWaterInfoResDTO(SharedPlant sharedPlant, Member currentMember) {
+        SharedPlantResDTO.LastWateredByDTO lastWateredBy = toLastWateredByDTO(currentMember);
+
+        return SharedPlantResDTO.WaterInfoResDTO.builder()
+                .sharedPlantId(sharedPlant.getId())
+                .growthValue(sharedPlant.getGrowthValue())
+                .growthStage(sharedPlant.getGrowthStage())
+                .lastWateredBy(lastWateredBy)
+                .status(sharedPlant.getStatus())
+                .isSoloMode(sharedPlant.getIsSoloMode())
+                .nutrientCount(currentMember.getNutrientCount())
                 .build();
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
@@ -1,11 +1,14 @@
 package com.cotato.itda.domain.garden.converter;
 
+import com.cotato.itda.domain.friendship.entity.Friendship;
+import com.cotato.itda.domain.garden.dto.SharedPlantWithFriendship;
 import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
 import com.cotato.itda.domain.garden.entity.SharedPlant;
 import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
 import com.cotato.itda.domain.member.entity.Member;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 public class SharedPlantConverter {
 
@@ -26,17 +29,43 @@ public class SharedPlantConverter {
                 .build();
     }
 
-    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant) {
+    public static SharedPlantResDTO.AcceptedSharedPlantDTO toAcceptedSharedPlantDTO(SharedPlant sharedPlant) {
+        return SharedPlantResDTO.AcceptedSharedPlantDTO.builder()
+                .sharedPlantId(sharedPlant.getId())
+                .plantId(sharedPlant.getPlant().getId())
+                .nickname(sharedPlant.getNickname())
+                .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+
+    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant, Friendship friendship) {
         return SharedPlantResDTO.SharedPlantInfoDTO.builder()
                 .sharedPlantId(sharedPlant.getId())
-                .memberAId(sharedPlant.getMemberA().getId())
-                .memberBId(sharedPlant.getMemberB().getId())
+                .friendId(friendship.getFriendId())
+                .friendNickname(friendship.getDisplayName())
                 .plantId(sharedPlant.getPlant().getId())
                 .nickname(sharedPlant.getNickname())
                 .growthValue(sharedPlant.getGrowthValue())
                 .growthStage(sharedPlant.getGrowthStage())
                 .status(sharedPlant.getStatus())
+                .isSoloMode(sharedPlant.getIsSoloMode())
                 .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+
+    public static SharedPlantResDTO.SharedPlantInfoListDTO toSharedPlantInfoListDTO(
+            List<SharedPlantWithFriendship> sharedPlantsWithFriendships,
+            int nutrientCount
+    ) {
+        List<SharedPlantResDTO.SharedPlantInfoDTO> sharedPlantInfoDTOs = sharedPlantsWithFriendships.stream()
+                .filter(pair -> pair.friendship() != null)
+                .map(pair -> toSharedPlantInfoDTO(pair.sharedPlant(), pair.friendship()))
+                .toList();
+
+        return SharedPlantResDTO.SharedPlantInfoListDTO.builder()
+                .totalCount(sharedPlantInfoDTOs.size())
+                .nutrientCount(nutrientCount)
+                .sharedPlants(sharedPlantInfoDTOs)
                 .build();
     }
 

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
@@ -1,0 +1,42 @@
+package com.cotato.itda.domain.garden.converter;
+
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO.SharedPlantInfoDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.member.entity.Member;
+
+import java.time.format.DateTimeFormatter;
+
+public class SharedPlantConverter {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public static SharedPlant toSharedPlant(SharedPlantInvite invite) {
+        Member inviter = invite.getInviter();
+        Member invitee = invite.getInvitee();
+
+        Member memberA = inviter.getId() < invitee.getId() ? inviter : invitee;
+        Member memberB = inviter.getId() < invitee.getId() ? invitee : inviter;
+
+        return SharedPlant.builder()
+                .plant(invite.getPlant())
+                .memberA(memberA)
+                .memberB(memberB)
+                .nickname(invite.getNickname())
+                .build();
+    }
+
+    public static SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant) {
+        return SharedPlantInfoDTO.builder()
+                .sharedPlantId(sharedPlant.getId())
+                .memberAId(sharedPlant.getMemberA().getId())
+                .memberBId(sharedPlant.getMemberB().getId())
+                .plantId(sharedPlant.getPlant().getId())
+                .nickname(sharedPlant.getNickname())
+                .growthValue(sharedPlant.getGrowthValue())
+                .growthStage(sharedPlant.getGrowthStage().name())
+                .status(sharedPlant.getStatus().name())
+                .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
@@ -38,7 +38,15 @@ public class SharedPlantConverter {
                 .build();
     }
 
-    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant, Friendship friendship) {
+    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant, Friendship friendship, Long currentMemberId) {
+        SharedPlantResDTO.LastWateredByDTO lastWateredBy = null;
+        if (sharedPlant.getLastWateredBy() != null) {
+            lastWateredBy = SharedPlantResDTO.LastWateredByDTO.builder()
+                    .memberId(sharedPlant.getLastWateredBy())
+                    .isMe(sharedPlant.getLastWateredBy().equals(currentMemberId))
+                    .build();
+        }
+
         return SharedPlantResDTO.SharedPlantInfoDTO.builder()
                 .sharedPlantId(sharedPlant.getId())
                 .friendId(friendship.getFriendId())
@@ -49,17 +57,19 @@ public class SharedPlantConverter {
                 .growthStage(sharedPlant.getGrowthStage())
                 .status(sharedPlant.getStatus())
                 .isSoloMode(sharedPlant.getIsSoloMode())
+                .lastWateredBy(lastWateredBy)
                 .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
                 .build();
     }
 
     public static SharedPlantResDTO.SharedPlantInfoListDTO toSharedPlantInfoListDTO(
             List<SharedPlantWithFriendship> sharedPlantsWithFriendships,
-            int nutrientCount
+            int nutrientCount,
+            Long currentMemberId
     ) {
         List<SharedPlantResDTO.SharedPlantInfoDTO> sharedPlantInfoDTOs = sharedPlantsWithFriendships.stream()
                 .filter(pair -> pair.friendship() != null)
-                .map(pair -> toSharedPlantInfoDTO(pair.sharedPlant(), pair.friendship()))
+                .map(pair -> toSharedPlantInfoDTO(pair.sharedPlant(), pair.friendship(), currentMemberId))
                 .toList();
 
         return SharedPlantResDTO.SharedPlantInfoListDTO.builder()

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantConverter.java
@@ -7,8 +7,10 @@ import com.cotato.itda.domain.garden.entity.SharedPlant;
 import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
 import com.cotato.itda.domain.member.entity.Member;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 public class SharedPlantConverter {
 
@@ -38,7 +40,12 @@ public class SharedPlantConverter {
                 .build();
     }
 
-    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(SharedPlant sharedPlant, Friendship friendship, Long currentMemberId) {
+    public static SharedPlantResDTO.SharedPlantInfoDTO toSharedPlantInfoDTO(
+            SharedPlant sharedPlant,
+            Friendship friendship,
+            Long currentMemberId,
+            LocalDateTime myLastWateredAt
+    ) {
         SharedPlantResDTO.LastWateredByDTO lastWateredBy = null;
         if (sharedPlant.getLastWateredBy() != null) {
             lastWateredBy = SharedPlantResDTO.LastWateredByDTO.builder()
@@ -58,6 +65,7 @@ public class SharedPlantConverter {
                 .status(sharedPlant.getStatus())
                 .isSoloMode(sharedPlant.getIsSoloMode())
                 .lastWateredBy(lastWateredBy)
+                .myLastWateredAt(myLastWateredAt != null ? myLastWateredAt.format(FORMATTER) : null)
                 .createdAt(sharedPlant.getCreatedAt().format(FORMATTER))
                 .build();
     }
@@ -65,11 +73,17 @@ public class SharedPlantConverter {
     public static SharedPlantResDTO.SharedPlantInfoListDTO toSharedPlantInfoListDTO(
             List<SharedPlantWithFriendship> sharedPlantsWithFriendships,
             int nutrientCount,
-            Long currentMemberId
+            Long currentMemberId,
+            Map<Long, LocalDateTime> myLastWateredAtMap
     ) {
         List<SharedPlantResDTO.SharedPlantInfoDTO> sharedPlantInfoDTOs = sharedPlantsWithFriendships.stream()
                 .filter(pair -> pair.friendship() != null)
-                .map(pair -> toSharedPlantInfoDTO(pair.sharedPlant(), pair.friendship(), currentMemberId))
+                .map(pair -> toSharedPlantInfoDTO(
+                        pair.sharedPlant(),
+                        pair.friendship(),
+                        currentMemberId,
+                        myLastWateredAtMap.get(pair.sharedPlant().getId())
+                ))
                 .toList();
 
         return SharedPlantResDTO.SharedPlantInfoListDTO.builder()

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantInviteConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantInviteConverter.java
@@ -1,0 +1,84 @@
+package com.cotato.itda.domain.garden.converter;
+
+import com.cotato.itda.domain.friendship.entity.Friendship;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO.*;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SharedPlantInviteConverter {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public static InviteCandidateInfoDTO toInviteCandidateInfoDTO(Friendship friendship) {
+        return InviteCandidateInfoDTO.builder()
+                .friendshipId(friendship.getId())
+                .nickname(friendship.getDisplayName())
+                .profileImageUrl(friendship.getFriend().getProfileImageUrl())
+                .friendId(friendship.getFriend().getId())
+                .build();
+    }
+
+    public static CreateSharedPlantInviteResDTO toCreateSharedPlantInviteResDTO(SharedPlantInvite invite) {
+        return CreateSharedPlantInviteResDTO.builder()
+                .inviteId(invite.getId())
+                .status(invite.getStatus().name())
+                .createdAt(invite.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+
+    public static MyPlantInviteResDTO toMyPlantInviteResDTO(SharedPlantInvite invite, String inviterName) {
+        return MyPlantInviteResDTO.builder()
+                .inviteId(invite.getId())
+                .plantId(invite.getPlant().getId())
+                .inviterId(invite.getInviter().getId())
+                .inviterName(inviterName)
+                .nickname(invite.getNickname())
+                .message(invite.getMessage())
+                .status(invite.getStatus().name())
+                .createdAt(invite.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+
+    public static PlantInviteCandidatesResDto toPlantInviteCandidatesResDto(List<Friendship> friendships) {
+        List<InviteCandidateInfoDTO> candidateInfos = friendships.stream()
+                .map(SharedPlantInviteConverter::toInviteCandidateInfoDTO)
+                .toList();
+
+        return PlantInviteCandidatesResDto.builder()
+                .count(candidateInfos.size())
+                .friends(candidateInfos)
+                .build();
+    }
+
+    public static MyPlantInviteListResDTO toMyPlantInviteListResDTO(List<SharedPlantInvite> i, List<Friendship> f) {
+        Map<Long, String> inviterNames = f.stream()
+                .collect(Collectors.toMap(
+                        Friendship::getFriendId,
+                        Friendship::getDisplayName,
+                        (existing, replacement) -> existing // 중복 방지
+                ));
+
+        List<MyPlantInviteResDTO> inviteInfos = i.stream()
+                .map(invite -> toMyPlantInviteResDTO(invite,
+                        inviterNames.getOrDefault(invite.getInviter().getId(), invite.getInviter().getName())))
+                .toList();
+
+        return MyPlantInviteListResDTO.builder()
+                .count(inviteInfos.size())
+                .invitations(inviteInfos)
+                .build();
+    }
+
+    public static UpdateSharedPlantInviteResDTO toUpdateSharedPlantInviteResDTO(SharedPlantInvite invite, SharedPlant sharedPlant) {
+        return UpdateSharedPlantInviteResDTO.builder()
+                .inviteId(invite.getId())
+                .status(invite.getStatus().name())
+                .sharedPlant(sharedPlant != null ? SharedPlantConverter.toSharedPlantInfoDTO(sharedPlant) : null)
+                .build();
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantInviteConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantInviteConverter.java
@@ -78,7 +78,7 @@ public class SharedPlantInviteConverter {
         return UpdateSharedPlantInviteResDTO.builder()
                 .inviteId(invite.getId())
                 .status(invite.getStatus().name())
-                .sharedPlant(sharedPlant != null ? SharedPlantConverter.toSharedPlantInfoDTO(sharedPlant) : null)
+                .sharedPlant(sharedPlant != null ? SharedPlantConverter.toAcceptedSharedPlantDTO(sharedPlant) : null)
                 .build();
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantLogConverter.java
+++ b/src/main/java/com/cotato/itda/domain/garden/converter/SharedPlantLogConverter.java
@@ -1,0 +1,23 @@
+package com.cotato.itda.domain.garden.converter;
+
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantLog;
+
+public class SharedPlantLogConverter {
+
+    public static SharedPlantLog toSharedPlantLog(
+            SharedPlant sharedPlant,
+            Long wateredBy,
+            boolean affectedGrowth,
+            int growthIncrement,
+            boolean usedNutrient
+    ) {
+        return SharedPlantLog.builder()
+                .sharedPlant(sharedPlant)
+                .wateredBy(wateredBy)
+                .affectedGrowth(affectedGrowth)
+                .growthIncrement(growthIncrement)
+                .usedNutrient(usedNutrient)
+                .build();
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/SharedPlantWithFriendship.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/SharedPlantWithFriendship.java
@@ -1,0 +1,9 @@
+package com.cotato.itda.domain.garden.dto;
+
+import com.cotato.itda.domain.friendship.entity.Friendship;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+
+public record SharedPlantWithFriendship(
+        SharedPlant sharedPlant,
+        Friendship friendship
+) {}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/req/PlantInviteReqDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/req/PlantInviteReqDTO.java
@@ -1,0 +1,23 @@
+package com.cotato.itda.domain.garden.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class PlantInviteReqDTO {
+
+    public record CreateSharedPlantInviteReqDTO(
+            @Schema(description = "초대받을 친구 회원 ID", example = "12") @NotNull(message = "초대받을 친구 ID는 필수입니다.") Long inviteeId,
+
+            @Schema(description = "식물 ID", example = "1") @NotNull(message = "식물 ID는 필수입니다.") Long plantId,
+
+            @Schema(description = "함께 키울 식물 닉네임", example = "두쫀쿠") @NotBlank(message = "식물 닉네임은 필수입니다.") @Size(max = 20, message = "닉네임은 20자 이내여야 합니다.") String nickname,
+
+            @Schema(description = "초대 메시지", example = "우리 같이 식물 키우자!") @NotBlank(message = "초대 메시지는 필수입니다.") @Size(max = 100, message = "초대 메시지는 100자 이내여야 합니다.") String message) {
+    }
+
+    public record UpdateSharedPlantInviteReqDTO(
+            @Schema(description = "수락/거절 상태 (ACCEPTED, REJECTED)", example = "ACCEPTED") @NotNull(message = "상태값은 필수입니다.") com.cotato.itda.domain.garden.enums.InviteStatus status) {
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/req/PlantReqDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/req/PlantReqDTO.java
@@ -1,0 +1,33 @@
+package com.cotato.itda.domain.garden.dto.req;
+
+import com.cotato.itda.domain.garden.enums.PlantDifficulty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class PlantReqDTO {
+
+    public record CreatePlantReqDTO(
+            @NotBlank(message = "이름은 필수입니다.")
+            @Size(min = 2, max = 20, message = "이름은 2~20자 사이여야 합니다.")
+            String name,
+            @NotNull(message = "난이도는 필수입니다.")
+            PlantDifficulty difficulty,
+            @NotNull(message = "기간은 필수입니다.")
+            Integer duration,
+            @NotBlank(message = "해시태그는 필수입니다.")
+            String hashtags,
+            @NotNull(message = "높이는 필수입니다.")
+            Integer height,
+            @NotNull(message = "최대 씨앗 성장값은 필수입니다.")
+            Integer seedMax,
+            @NotNull(message = "최대 새싹 성장값은 필수입니다.")
+            Integer sproutMax,
+            @NotNull(message = "최대 줄기 성장값은 필수입니다.")
+            Integer stemMax,
+            @NotNull(message = "최대 꽃봉오리 성장값은 필수입니다.")
+            Integer budMax,
+            @NotNull(message = "최대 만개 성장값은 필수입니다.")
+            Integer bloomMax
+    ) {}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/req/SharedPlantReqDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/req/SharedPlantReqDTO.java
@@ -1,0 +1,12 @@
+package com.cotato.itda.domain.garden.dto.req;
+
+import com.cotato.itda.domain.garden.enums.SupplyType;
+import jakarta.validation.constraints.NotNull;
+
+public class SharedPlantReqDTO {
+
+    public record WaterPlantReqDTO(
+            @NotNull(message = "물주기 타입은 필수입니다.")
+            SupplyType supplyType
+    ) {}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
@@ -1,0 +1,67 @@
+package com.cotato.itda.domain.garden.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import java.util.List;
+
+public class PlantInviteResDTO {
+
+        @Builder
+        public record PlantInviteCandidatesResDto(
+                        @Schema(description = "후보 친구 수", example = "3") Integer count,
+                        @Schema(description = "후보 친구 목록") List<InviteCandidateInfoDTO> friends) {
+        }
+
+        @Builder
+        public record InviteCandidateInfoDTO(
+                        @Schema(description = "친구 관계 ID", example = "10") Long friendshipId,
+                        @Schema(description = "친구 닉네임 (별명 또는 본명)", example = "길동이") String nickname,
+                        @Schema(description = "친구 프로필 이미지 URL", example = "https://example.com/profile.jpg") String profileImageUrl,
+                        @Schema(description = "친구 회원 ID", example = "12") Long friendId) {
+        }
+
+        @Builder
+        public record CreateSharedPlantInviteResDTO(
+                        @Schema(description = "초대 ID", example = "12") Long inviteId,
+                        @Schema(description = "초대 상태", example = "PENDING") String status,
+                        @Schema(description = "생성 일시", example = "2025-12-28 12:23") String createdAt) {
+        }
+
+        @Builder
+        public record MyPlantInviteListResDTO(
+                        @Schema(description = "초대 수", example = "1") Integer count,
+                        @Schema(description = "초대 목록") List<MyPlantInviteResDTO> invitations) {
+        }
+
+        @Builder
+        public record MyPlantInviteResDTO(
+                        @Schema(description = "초대 ID", example = "12") Long inviteId,
+                        @Schema(description = "식물 ID", example = "1") Long plantId,
+                        @Schema(description = "초대자 회원 ID", example = "1") Long inviterId,
+                        @Schema(description = "초대자 보여지는 이름", example = "콩순이") String inviterName,
+                        @Schema(description = "식물 닉네임", example = "두쫀쿠") String nickname,
+                        @Schema(description = "초대 메시지", example = "같이 키워용") String message,
+                        @Schema(description = "초대 상태", example = "PENDING") String status,
+                        @Schema(description = "생성 일시", example = "2025-12-28 12:23") String createdAt) {
+        }
+
+        @Builder
+        public record UpdateSharedPlantInviteResDTO(
+                        @Schema(description = "초대 ID", example = "1") Long inviteId,
+                        @Schema(description = "초대 상태", example = "ACCEPTED") String status,
+                        @Schema(description = "공유 식물 상세 정보 (수락 시에만 포함)") SharedPlantInfoDTO sharedPlant) {
+        }
+
+        @Builder
+        public record SharedPlantInfoDTO(
+                        @Schema(description = "공유 식물 ID", example = "1") Long sharedPlantId,
+                        @Schema(description = "멤버 A ID (초대자)", example = "1") Long memberAId,
+                        @Schema(description = "멤버 B ID (초대받은 자)", example = "2") Long memberBId,
+                        @Schema(description = "식물 ID", example = "1") Long plantId,
+                        @Schema(description = "식물 닉네임", example = "두쫀쿠") String nickname,
+                        @Schema(description = "성장 정도", example = "0") int growthValue,
+                        @Schema(description = "성장 단계", example = "SEED") String growthStage,
+                        @Schema(description = "상태", example = "GROWING") String status,
+                        @Schema(description = "생성 일시", example = "2025-12-28 12:34") String createdAt) {
+        }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
@@ -49,19 +49,6 @@ public class PlantInviteResDTO {
         public record UpdateSharedPlantInviteResDTO(
                         @Schema(description = "초대 ID", example = "1") Long inviteId,
                         @Schema(description = "초대 상태", example = "ACCEPTED") String status,
-                        @Schema(description = "공유 식물 상세 정보 (수락 시에만 포함)") SharedPlantInfoDTO sharedPlant) {
-        }
-
-        @Builder
-        public record SharedPlantInfoDTO(
-                        @Schema(description = "공유 식물 ID", example = "1") Long sharedPlantId,
-                        @Schema(description = "멤버 A ID (초대자)", example = "1") Long memberAId,
-                        @Schema(description = "멤버 B ID (초대받은 자)", example = "2") Long memberBId,
-                        @Schema(description = "식물 ID", example = "1") Long plantId,
-                        @Schema(description = "식물 닉네임", example = "두쫀쿠") String nickname,
-                        @Schema(description = "성장 정도", example = "0") int growthValue,
-                        @Schema(description = "성장 단계", example = "SEED") String growthStage,
-                        @Schema(description = "상태", example = "GROWING") String status,
-                        @Schema(description = "생성 일시", example = "2025-12-28 12:34") String createdAt) {
+                        @Schema(description = "공유 식물 상세 정보 (수락 시에만 포함)") SharedPlantResDTO.SharedPlantInfoDTO sharedPlant) {
         }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantInviteResDTO.java
@@ -49,6 +49,6 @@ public class PlantInviteResDTO {
         public record UpdateSharedPlantInviteResDTO(
                         @Schema(description = "초대 ID", example = "1") Long inviteId,
                         @Schema(description = "초대 상태", example = "ACCEPTED") String status,
-                        @Schema(description = "공유 식물 상세 정보 (수락 시에만 포함)") SharedPlantResDTO.SharedPlantInfoDTO sharedPlant) {
+                        @Schema(description = "공유 식물 정보 (수락 시에만 포함)") SharedPlantResDTO.AcceptedSharedPlantDTO sharedPlant) {
         }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/PlantResDTO.java
@@ -1,0 +1,33 @@
+package com.cotato.itda.domain.garden.dto.res;
+
+import com.cotato.itda.domain.garden.enums.PlantDifficulty;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PlantResDTO {
+
+    @Builder
+    public record CreatePlantResDTO(
+            Long plantId,
+            String plantName,
+            LocalDateTime createdAt
+    ) {}
+
+    @Builder
+    public record PlantListResDto(
+            Integer count,
+            List<PlantInfoResDto> plants
+    ) {}
+
+    @Builder
+    public record PlantInfoResDto(
+            Long plantId,
+            String plantName,
+            PlantDifficulty difficulty,
+            Integer duration,
+            String hashtags,
+            Integer height
+    ) {}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
@@ -1,0 +1,63 @@
+package com.cotato.itda.domain.garden.dto.res;
+
+import com.cotato.itda.domain.garden.enums.PlantStage;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+public class SharedPlantResDTO {
+
+    @Builder
+    @Schema(description = "물 주기 후 식물 정보 응답 DTO")
+    public record WaterInfoResDTO(
+            @Schema(description = "공유 식물 ID", example = "1")
+            Long sharedPlantId,
+            @Schema(description = "성장 정도", example = "12")
+            Integer growthValue,
+            @Schema(description = "성장 단계", example = "SPROUT")
+            PlantStage growthStage,
+            @Schema(description = "마지막으로 물 준 회원 정보")
+            LastWateredByDTO lastWateredBy,
+            @Schema(description = "공유 식물의 현재 상태", example = "GROWING")
+            SharedPlantStatus status,
+            @JsonProperty("isSoloMode")
+            @Schema(description = "혼자 돌봄 모드 여부", example = "false")
+            boolean isSoloMode,
+            @Schema(description = "현재 회원이 보유한 영양제 총 개수", example = "10")
+            Integer nutrientCount
+    ) {}
+
+    @Builder
+    @Schema(description = "마지막으로 물 준 회원 정보 DTO")
+    public record LastWateredByDTO(
+            @Schema(description = "회원 ID", example = "1")
+            Long memberId,
+            @JsonProperty("isMe")
+            @Schema(description = "요청한 회원이 물을 주었는지 여부", example = "true")
+            boolean isMe
+    ) {}
+
+    @Builder
+    @Schema(description = "공유 식물 상세 정보 응답 DTO")
+    public record SharedPlantInfoDTO(
+            @Schema(description = "공유 식물 ID", example = "1")
+            Long sharedPlantId,
+            @Schema(description = "멤버 A ID (초대자)", example = "1")
+            Long memberAId,
+            @Schema(description = "멤버 B ID (초대받은 자)", example = "2")
+            Long memberBId,
+            @Schema(description = "식물 ID", example = "1")
+            Long plantId,
+            @Schema(description = "식물 닉네임", example = "두쫀쿠")
+            String nickname,
+            @Schema(description = "성장 정도", example = "0")
+            int growthValue,
+            @Schema(description = "성장 단계", example = "SEED")
+            PlantStage growthStage, // String -> PlantStage Enum으로 변경
+            @Schema(description = "상태", example = "GROWING")
+            SharedPlantStatus status, // String -> SharedPlantStatus Enum으로 변경
+            @Schema(description = "생성 일시", example = "2025-12-28 12:34:56")
+            String createdAt
+    ) {}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
@@ -75,6 +75,8 @@ public class SharedPlantResDTO {
             @JsonProperty("isSoloMode")
             @Schema(description = "혼자 돌봄 모드 여부", example = "false")
             boolean isSoloMode,
+            @Schema(description = "마지막으로 물 준 회원 정보")
+            LastWateredByDTO lastWateredBy,
             @Schema(description = "생성 일시", example = "2025-12-28 12:34")
             String createdAt
     ) {}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
@@ -77,6 +77,8 @@ public class SharedPlantResDTO {
             boolean isSoloMode,
             @Schema(description = "마지막으로 물 준 회원 정보")
             LastWateredByDTO lastWateredBy,
+            @Schema(description = "내가 마지막으로 물 준 시간 (물을 준 적 없으면 null)", example = "2025-01-15 14:30")
+            String myLastWateredAt,
             @Schema(description = "생성 일시", example = "2025-12-28 12:34")
             String createdAt
     ) {}

--- a/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
+++ b/src/main/java/com/cotato/itda/domain/garden/dto/res/SharedPlantResDTO.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.util.List;
+
 public class SharedPlantResDTO {
 
     @Builder
@@ -39,14 +41,27 @@ public class SharedPlantResDTO {
     ) {}
 
     @Builder
+    @Schema(description = "초대 수락 시 생성된 공유 식물 정보 응답 DTO")
+    public record AcceptedSharedPlantDTO(
+            @Schema(description = "공유 식물 ID", example = "1")
+            Long sharedPlantId,
+            @Schema(description = "식물 ID", example = "1")
+            Long plantId,
+            @Schema(description = "식물 닉네임", example = "두쫀쿠")
+            String nickname,
+            @Schema(description = "생성 일시", example = "2025-12-28 12:34")
+            String createdAt
+    ) {}
+
+    @Builder
     @Schema(description = "공유 식물 상세 정보 응답 DTO")
     public record SharedPlantInfoDTO(
             @Schema(description = "공유 식물 ID", example = "1")
             Long sharedPlantId,
-            @Schema(description = "멤버 A ID (초대자)", example = "1")
-            Long memberAId,
-            @Schema(description = "멤버 B ID (초대받은 자)", example = "2")
-            Long memberBId,
+            @Schema(description = "친구 ID", example = "2")
+            Long friendId,
+            @Schema(description = "친구 닉네임", example = "콩순이")
+            String friendNickname,
             @Schema(description = "식물 ID", example = "1")
             Long plantId,
             @Schema(description = "식물 닉네임", example = "두쫀쿠")
@@ -54,10 +69,24 @@ public class SharedPlantResDTO {
             @Schema(description = "성장 정도", example = "0")
             int growthValue,
             @Schema(description = "성장 단계", example = "SEED")
-            PlantStage growthStage, // String -> PlantStage Enum으로 변경
+            PlantStage growthStage,
             @Schema(description = "상태", example = "GROWING")
-            SharedPlantStatus status, // String -> SharedPlantStatus Enum으로 변경
-            @Schema(description = "생성 일시", example = "2025-12-28 12:34:56")
+            SharedPlantStatus status,
+            @JsonProperty("isSoloMode")
+            @Schema(description = "혼자 돌봄 모드 여부", example = "false")
+            boolean isSoloMode,
+            @Schema(description = "생성 일시", example = "2025-12-28 12:34")
             String createdAt
+    ) {}
+
+    @Builder
+    @Schema(description = "공유 식물 상세 정보 응답 리스트 DTO")
+    public record SharedPlantInfoListDTO(
+            @Schema(description = "공유 식물 총 개수", example = "3")
+            int totalCount,
+            @Schema(description = "개인 영양제 보유량", example = "2")
+            int nutrientCount,
+            @Schema(description = "공유 식물 상세 정보")
+            List<SharedPlantInfoDTO> sharedPlants
     ) {}
 }

--- a/src/main/java/com/cotato/itda/domain/garden/entity/Plant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/Plant.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(name = "plants", uniqueConstraints = @UniqueConstraint(columnNames = {"name"}))
+@Table(name = "plants", uniqueConstraints = @UniqueConstraint(columnNames = { "name" }))
 public class Plant extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 20)

--- a/src/main/java/com/cotato/itda/domain/garden/entity/Plant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/Plant.java
@@ -1,0 +1,55 @@
+package com.cotato.itda.domain.garden.entity;
+
+import com.cotato.itda.domain.garden.enums.PlantDifficulty;
+import com.cotato.itda.domain.garden.enums.PlantStage;
+import com.cotato.itda.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "plants", uniqueConstraints = @UniqueConstraint(columnNames = {"name"}))
+public class Plant extends BaseEntity {
+
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+
+    @Column(name = "difficulty", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PlantDifficulty difficulty;
+
+    @Column(name = "duration", nullable = false)
+    private int duration;
+
+    @Column(name = "hashtags", nullable = false)
+    private String hashtags;
+
+    @Column(name = "height", nullable = false)
+    private int height;
+
+    @Column(name = "seed_max", nullable = false)
+    private int seedMax;
+
+    @Column(name = "sprout_max", nullable = false)
+    private int sproutMax;
+
+    @Column(name = "stem_max", nullable = false)
+    private int stemMax;
+
+    @Column(name = "bud_max", nullable = false)
+    private int budMax;
+
+    @Column(name = "bloom_max", nullable = false)
+    private int bloomMax;
+
+    public PlantStage calculateGrowthStage(int growthValue) {
+        if (growthValue <= seedMax) return PlantStage.SEED;
+        else if (growthValue <= sproutMax) return PlantStage.SPROUT;
+        else if (growthValue <= stemMax) return PlantStage.STEM;
+        else if (growthValue <= budMax) return PlantStage.BUD;
+        else return PlantStage.BLOOM;
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
@@ -82,4 +82,16 @@ public class SharedPlant extends BaseEntity {
         this.isSoloMode = false;
         this.soloPowerMemberId = null;
     }
+
+    public void complete() {
+        this.status = SharedPlantStatus.COMPLETED;
+    }
+
+    public void revive() {
+        this.status = SharedPlantStatus.GROWING;
+    }
+
+    public boolean hasReachedMaxGrowth() {
+        return this.growthValue >= this.plant.getBloomMax();
+    }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
@@ -62,4 +62,24 @@ public class SharedPlant extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private SharedPlantStatus status = SharedPlantStatus.GROWING;
+
+    public void water(int growthValue, Member member, boolean isFirst) {
+        this.growthValue += growthValue;
+        this.growthStage = this.plant.calculateGrowthStage(this.growthValue);
+        if (isFirst) this.dailyGrowthCount = 1;
+        else this.dailyGrowthCount++;
+        this.lastWateredBy = member.getId();
+        this.growthDate = LocalDate.now();
+    }
+
+    public void nutrient(int growthValue, Member member) {
+        this.growthValue += growthValue;
+        this.growthStage = this.plant.calculateGrowthStage(this.growthValue);
+        member.decreaseNutrient();
+    }
+
+    public void exitSoloMode() {
+        this.isSoloMode = false;
+        this.soloPowerMemberId = null;
+    }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
@@ -37,6 +37,7 @@ public class SharedPlant extends BaseEntity {
     private int growthValue = 0;
 
     @Column(name = "growth_stage", nullable = false)
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private PlantStage growthStage = PlantStage.SEED;
 
@@ -58,6 +59,7 @@ public class SharedPlant extends BaseEntity {
     private Long soloPowerMemberId;
 
     @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private SharedPlantStatus status = SharedPlantStatus.GROWING;
 }

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
@@ -1,0 +1,63 @@
+package com.cotato.itda.domain.garden.entity;
+
+import com.cotato.itda.domain.garden.enums.PlantStage;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "shared_plants")
+public class SharedPlant extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_id", nullable = false)
+    private Plant plant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_a_id", nullable = false)
+    private Member memberA;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_b_id", nullable = false)
+    private Member memberB;
+
+    @Column(name = "nickname", nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name = "growth_value", nullable = false)
+    @Builder.Default
+    private int growthValue = 0;
+
+    @Column(name = "growth_stage", nullable = false)
+    @Builder.Default
+    private PlantStage growthStage = PlantStage.SEED;
+
+    @Column(name = "daily_growth_count", nullable = false)
+    @Builder.Default
+    private int dailyGrowthCount = 0;
+
+    @Column(name = "growth_date")
+    private LocalDate growthDate;
+
+    @Column(name = "last_watered_by")
+    private Long lastWateredBy;
+
+    @Column(name = "is_solo_mode", nullable = false)
+    @Builder.Default
+    private Boolean isSoloMode = false;
+
+    @Column(name = "solo_power_member_id")
+    private Long soloPowerMemberId;
+
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private SharedPlantStatus status = SharedPlantStatus.GROWING;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantInvite.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantInvite.java
@@ -1,0 +1,42 @@
+package com.cotato.itda.domain.garden.entity;
+
+import com.cotato.itda.domain.garden.enums.InviteStatus;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "shared_plant_invites")
+public class SharedPlantInvite extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_id", nullable = false)
+    private Plant plant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private Member inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id", nullable = false)
+    private Member invitee;
+
+    @Column(name = "nickname", nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name = "message", nullable = false, length = 100)
+    private String message;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private InviteStatus status;
+
+    public void updateStatus(InviteStatus newStatus) {
+        this.status = newStatus;
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantLog.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantLog.java
@@ -28,7 +28,8 @@ public class SharedPlantLog {
     private Long wateredBy;
 
     @Column(name = "watered_at", nullable = false)
-    private LocalDateTime wateredAt;
+    @Builder.Default
+    private LocalDateTime wateredAt = LocalDateTime.now();
 
     @Column(name = "affected_growth", nullable = false)
     private boolean affectedGrowth;

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantLog.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlantLog.java
@@ -1,0 +1,47 @@
+package com.cotato.itda.domain.garden.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "shared_plant_log")
+public class SharedPlantLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shared_plant_id", nullable = false)
+    private SharedPlant sharedPlant;
+
+    @Column(name = "watered_by", nullable = false)
+    private Long wateredBy;
+
+    @Column(name = "watered_at", nullable = false)
+    private LocalDateTime wateredAt;
+
+    @Column(name = "affected_growth", nullable = false)
+    private boolean affectedGrowth;
+
+    @Column(name = "growth_increment", nullable = false)
+    @Builder.Default
+    private int growthIncrement = 5;
+
+    @Column(name = "used_nutrient", nullable = false)
+    @Builder.Default
+    private boolean usedNutrient = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/GrowthType.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/GrowthType.java
@@ -1,0 +1,15 @@
+package com.cotato.itda.domain.garden.enums;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GrowthType {
+    NONE(0),
+    WATER(5),
+    NUTRIENT(5);
+
+    private final int growth;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/InviteStatus.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/InviteStatus.java
@@ -1,0 +1,5 @@
+package com.cotato.itda.domain.garden.enums;
+
+public enum InviteStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/MaxGrowthCount.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/MaxGrowthCount.java
@@ -1,0 +1,15 @@
+package com.cotato.itda.domain.garden.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MaxGrowthCount {
+
+    TEAM_GROW(4),
+    TEAM_WATER(2),
+    SOLO_WATER(1);
+
+    public final int maxGrowthCount;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/PlantDifficulty.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/PlantDifficulty.java
@@ -1,0 +1,5 @@
+package com.cotato.itda.domain.garden.enums;
+
+public enum PlantDifficulty {
+    EASY, NORMAL, HARD
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/PlantStage.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/PlantStage.java
@@ -1,0 +1,5 @@
+package com.cotato.itda.domain.garden.enums;
+
+public enum PlantStage {
+    SEED, SPROUT, STEM, BUD, BLOOM
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/SharedPlantStatus.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/SharedPlantStatus.java
@@ -1,0 +1,5 @@
+package com.cotato.itda.domain.garden.enums;
+
+public enum SharedPlantStatus {
+    GROWING, WITHERED, COMPLETED
+}

--- a/src/main/java/com/cotato/itda/domain/garden/enums/SupplyType.java
+++ b/src/main/java/com/cotato/itda/domain/garden/enums/SupplyType.java
@@ -1,0 +1,6 @@
+package com.cotato.itda.domain.garden.enums;
+
+public enum SupplyType {
+
+    WATER, NUTRIENT
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/PlantException.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/PlantException.java
@@ -1,0 +1,14 @@
+package com.cotato.itda.domain.garden.exception;
+
+import com.cotato.itda.domain.garden.exception.code.PlantErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import java.util.Map;
+
+public class PlantException extends BusinessException {
+    public PlantException(PlantErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public PlantException(PlantErrorCode errorCode, Map<String, Object> reasons) {super(errorCode, reasons);}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/SharedPlantException.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/SharedPlantException.java
@@ -1,0 +1,16 @@
+package com.cotato.itda.domain.garden.exception;
+
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import java.util.Map;
+
+public class SharedPlantException extends BusinessException {
+    public SharedPlantException(SharedPlantErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public SharedPlantException(SharedPlantErrorCode errorCode, Map<String, Object> reasons) {
+        super(errorCode, reasons);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/SharedPlantInviteException.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/SharedPlantInviteException.java
@@ -1,0 +1,16 @@
+package com.cotato.itda.domain.garden.exception;
+
+import com.cotato.itda.domain.garden.exception.code.SharedPlantInviteErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import java.util.Map;
+
+public class SharedPlantInviteException extends BusinessException {
+    public SharedPlantInviteException(SharedPlantInviteErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public SharedPlantInviteException(SharedPlantInviteErrorCode errorCode, Map<String, Object> reasons) {
+        super(errorCode, reasons);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/code/PlantErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/code/PlantErrorCode.java
@@ -1,0 +1,24 @@
+package com.cotato.itda.domain.garden.exception.code;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlantErrorCode implements ErrorCode {
+
+        NOT_FOUND(
+                        HttpStatus.NOT_FOUND,
+                        "PLANT_404_NOT_FOUND",
+                        "식물을 찾을 수 없습니다."),
+        DUPLICATE_NAME(
+                        HttpStatus.BAD_REQUEST,
+                        "PLANT_400_DUPLICATE_NAME",
+                        "이미 존재하는 식물 이름입니다.");
+
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
@@ -79,6 +79,12 @@ public enum SharedPlantErrorCode implements ErrorCode {
             "키우기가 완료된 식물에는 물을 줄 수 없습니다."
     ),
 
+    WITHERED_REQUIRES_NUTRIENT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_WITHERED_REQUIRES_NUTRIENT",
+            "시든 식물에는 영양제가 필요합니다."
+    ),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
@@ -1,0 +1,20 @@
+package com.cotato.itda.domain.garden.exception.code;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SharedPlantErrorCode implements ErrorCode {
+
+    ALREADY_HAS_SHARED_PLANT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_ALREADY_HAS_SHARED_PLANT",
+            "이미 키우고 있는 식물이 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantErrorCode.java
@@ -12,7 +12,74 @@ public enum SharedPlantErrorCode implements ErrorCode {
     ALREADY_HAS_SHARED_PLANT(
             HttpStatus.BAD_REQUEST,
             "SHARED_PLANT_400_ALREADY_HAS_SHARED_PLANT",
-            "이미 키우고 있는 식물이 있습니다.");
+            "이미 키우고 있는 식물이 있습니다."),
+
+    ALREADY_WATERED(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_ALREADY_WATERED",
+            "이미 물을 줬습니다."
+    ),
+
+    EXCEED_WATER_COUNT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_EXCEED_WATER_COUNT",
+            "물 주기 가능 횟수를 초과했습니다."
+    ),
+
+    NO_PERMISSION_TO_WATER_SOLO_PLANT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_NO_PERMISSION_TO_WATER_SOLO_PLANT",
+            "혼자 돌봄 모드에서 물을 줄 권한이 없습니다."
+    ),
+    CANNOT_WATER_CONSECUTIVELY(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_CANNOT_WATER_CONSECUTIVELY",
+            "연속으로 물을 줄 수 없습니다."
+    ),
+
+    NOT_FOUND_STRATEGY(
+            HttpStatus.NOT_FOUND,
+            "SHARED_PLANT_404_NOT_FOUND_STRATEGY",
+            "적절한 기본 물주기 전략을 찾을 수 없습니다."
+    ),
+
+    DONT_HAVE_NUTRIENT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_DONT_HAVE_NUTRIENT",
+            "영양제가 없습니다."
+    ),
+
+    ALREADY_GAVE_NUTRIENT_TODAY(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_ALREADY_GAVE_NUTRIENT_TODAY",
+            "오늘 이미 영양제를 줬습니다."
+    ),
+
+    SHARED_PLANT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "SHARED_PLANT_400_SHARED_PLANT_NOT_FOUND",
+            "함께 키우는 식물을 찾지 못했습니다."
+    ),
+
+    CANNOT_USE_NUTRIENT_YET(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_CANNOT_USE_NUTRIENT_YET",
+            "아직 영양제를 줄 수 없습니다."
+    ),
+
+    NOT_A_PARTICIPANT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_NOT_A_PARTICIPANT",
+            "함께 키우는 식물 참여자가 아닙니다."
+    ),
+
+    CANNOT_WATER_COMPLETED_PLANT(
+            HttpStatus.BAD_REQUEST,
+            "SHARED_PLANT_400_CANNOT_WATER_COMPLETED_PLANT",
+            "키우기가 완료된 식물에는 물을 줄 수 없습니다."
+    ),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantInviteErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/garden/exception/code/SharedPlantInviteErrorCode.java
@@ -1,0 +1,46 @@
+package com.cotato.itda.domain.garden.exception.code;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SharedPlantInviteErrorCode implements ErrorCode {
+
+        ALREADY_HAS_PENDING_INVITE(
+                        HttpStatus.BAD_REQUEST,
+                        "SHARED_PLANT_INVITE_400_ALREADY_HAS_PENDING_INVITE",
+                        "이미 초대 요청이 있는 친구입니다."
+        ),
+        SELF_INVITE_NOT_ALLOWED(
+                        HttpStatus.BAD_REQUEST,
+                        "SHARED_PLANT_INVITE_400_SELF_INVITE_NOT_ALLOWED",
+                        "본인 자신을 초대할 수 없습니다."
+        ),
+        INVITE_NOT_FOUND(
+                        HttpStatus.NOT_FOUND,
+                        "SHARED_PLANT_INVITE_404_NOT_FOUND",
+                        "존재하지 않는 초대입니다."
+        ),
+        NOT_INVITEE(
+                        HttpStatus.FORBIDDEN,
+                        "SHARED_PLANT_INVITE_403_NOT_INVITEE",
+                        "초대받은 사람만 접근할 수 있습니다."
+        ),
+        INVITE_NOT_PENDING(
+                        HttpStatus.BAD_REQUEST,
+                        "SHARED_PLANT_INVITE_400_NOT_PENDING",
+                        "대기 중인 초대장만 처리할 수 있습니다."
+        ),
+        INVALID_INVITE_STATUS(
+                        HttpStatus.BAD_REQUEST,
+                        "SHARED_PLANT_INVITE_400_INVALID_INVITE_STATUS",
+                        "초대장 상태는 ACCEPTED 또는 REJECTED여야 합니다."
+        );
+
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+}

--- a/src/main/java/com/cotato/itda/domain/garden/repository/PlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/PlantRepository.java
@@ -3,5 +3,21 @@ package com.cotato.itda.domain.garden.repository;
 import com.cotato.itda.domain.garden.entity.Plant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+
 public interface PlantRepository extends JpaRepository<Plant, Long> {
+    boolean existsByName(String name);
+
+    @Query("SELECT p FROM Plant p ORDER BY " +
+            "CASE p.difficulty WHEN com.cotato.itda.domain.garden.enums.PlantDifficulty.EASY THEN 0 " +
+            "WHEN com.cotato.itda.domain.garden.enums.PlantDifficulty.NORMAL THEN 1 " +
+            "ELSE 2 END ASC")
+    List<Plant> findAllOrderByDifficultyAsc();
+
+    @Query("SELECT p FROM Plant p ORDER BY " +
+            "CASE p.difficulty WHEN com.cotato.itda.domain.garden.enums.PlantDifficulty.EASY THEN 0 " +
+            "WHEN com.cotato.itda.domain.garden.enums.PlantDifficulty.NORMAL THEN 1 " +
+            "ELSE 2 END DESC")
+    List<Plant> findAllOrderByDifficultyDesc();
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/PlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/PlantRepository.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.garden.repository;
+
+import com.cotato.itda.domain.garden.entity.Plant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlantRepository extends JpaRepository<Plant, Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantInviteRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantInviteRepository.java
@@ -1,7 +1,25 @@
 package com.cotato.itda.domain.garden.repository;
 
 import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.garden.enums.InviteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
 public interface SharedPlantInviteRepository extends JpaRepository<SharedPlantInvite, Long> {
+    @Query("SELECT CASE WHEN spi.inviter.id = :memberId THEN spi.invitee.id ELSE spi.inviter.id END " +
+            "FROM SharedPlantInvite spi " +
+            "WHERE (spi.inviter.id = :memberId OR spi.invitee.id = :memberId) " +
+            "AND spi.status = com.cotato.itda.domain.garden.enums.InviteStatus.PENDING")
+    List<Long> findPendingInviteFriendIds(@Param("memberId") Long memberId);
+
+    @Query("SELECT COUNT(spi) > 0 FROM SharedPlantInvite spi " +
+            "WHERE ((spi.inviter.id = :memberId1 AND spi.invitee.id = :memberId2) " +
+            "OR (spi.inviter.id = :memberId2 AND spi.invitee.id = :memberId1)) " +
+            "AND spi.status = com.cotato.itda.domain.garden.enums.InviteStatus.PENDING")
+    boolean existsPendingInviteBetween(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
+
+    List<SharedPlantInvite> findAllByInviteeIdAndStatusOrderByCreatedAtAsc(Long inviteeId, InviteStatus status);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantInviteRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantInviteRepository.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.garden.repository;
+
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SharedPlantInviteRepository extends JpaRepository<SharedPlantInvite, Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.garden.repository;
+
+import com.cotato.itda.domain.garden.entity.SharedPlantLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SharedPlantLogRepository extends JpaRepository<SharedPlantLog, Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
@@ -1,7 +1,19 @@
 package com.cotato.itda.domain.garden.repository;
 
+import com.cotato.itda.domain.garden.entity.SharedPlant;
 import com.cotato.itda.domain.garden.entity.SharedPlantLog;
+import com.cotato.itda.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface SharedPlantLogRepository extends JpaRepository<SharedPlantLog, Long> {
+
+    boolean existsBySharedPlantAndWateredByAndUsedNutrientAndCreatedAtBetween(
+            SharedPlant sharedPlant,
+            Long wateredBy,
+            boolean usedNutrient,
+            LocalDateTime startOfDay,
+            LocalDateTime endOfDay
+    );
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantLogRepository.java
@@ -4,8 +4,11 @@ import com.cotato.itda.domain.garden.entity.SharedPlant;
 import com.cotato.itda.domain.garden.entity.SharedPlantLog;
 import com.cotato.itda.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface SharedPlantLogRepository extends JpaRepository<SharedPlantLog, Long> {
 
@@ -15,5 +18,14 @@ public interface SharedPlantLogRepository extends JpaRepository<SharedPlantLog, 
             boolean usedNutrient,
             LocalDateTime startOfDay,
             LocalDateTime endOfDay
+    );
+
+    @Query("SELECT spl FROM SharedPlantLog spl " +
+            "WHERE spl.sharedPlant.id IN :sharedPlantIds AND spl.wateredBy = :memberId " +
+            "AND spl.wateredAt = (SELECT MAX(spl2.wateredAt) FROM SharedPlantLog spl2 " +
+            "WHERE spl2.sharedPlant.id = spl.sharedPlant.id AND spl2.wateredBy = :memberId)")
+    List<SharedPlantLog> findLatestLogsBySharedPlantIdsAndMemberId(
+            @Param("sharedPlantIds") List<Long> sharedPlantIds,
+            @Param("memberId") Long memberId
     );
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -1,10 +1,11 @@
 package com.cotato.itda.domain.garden.repository;
 
 import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> {
@@ -18,4 +19,10 @@ public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> 
             "WHERE sp.memberA.id = :memberId1 AND sp.memberB.id = :memberId2 " +
             "AND sp.status IN (com.cotato.itda.domain.garden.enums.SharedPlantStatus.GROWING, com.cotato.itda.domain.garden.enums.SharedPlantStatus.WITHERED)")
     boolean existsGrowingOrWitheredBetween(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
+
+    @Query("SELECT sp FROM SharedPlant sp " +
+            "WHERE (sp.memberA.id = :memberId OR sp.memberB.id = :memberId) " +
+            "AND sp.status IN :statuses " +
+            "ORDER BY sp.createdAt DESC")
+    List<SharedPlant> findAllByMemberIdAndStatusIn(@Param("memberId") Long memberId, @Param("statuses") List<SharedPlantStatus> statuses);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -3,5 +3,19 @@ package com.cotato.itda.domain.garden.repository;
 import com.cotato.itda.domain.garden.entity.SharedPlant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
 public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> {
+    @Query("SELECT CASE WHEN sp.memberA.id = :memberId THEN sp.memberB.id ELSE sp.memberA.id END " +
+            "FROM SharedPlant sp " +
+            "WHERE (sp.memberA.id = :memberId OR sp.memberB.id = :memberId) " +
+            "AND sp.status IN (com.cotato.itda.domain.garden.enums.SharedPlantStatus.GROWING, com.cotato.itda.domain.garden.enums.SharedPlantStatus.WITHERED)")
+    List<Long> findGrowingOrWitheredSharedPlantFriendIds(@Param("memberId") Long memberId);
+
+    @Query("SELECT COUNT(sp) > 0 FROM SharedPlant sp " +
+            "WHERE sp.memberA.id = :memberId1 AND sp.memberB.id = :memberId2 " +
+            "AND sp.status IN (com.cotato.itda.domain.garden.enums.SharedPlantStatus.GROWING, com.cotato.itda.domain.garden.enums.SharedPlantStatus.WITHERED)")
+    boolean existsGrowingOrWitheredBetween(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.garden.repository;
+
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/PlantCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/PlantCommandService.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.garden.dto.req.PlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+
+public interface PlantCommandService {
+    PlantResDTO.CreatePlantResDTO createPlant(PlantReqDTO.CreatePlantReqDTO dto);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/PlantCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/PlantCommandServiceImpl.java
@@ -1,0 +1,33 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.garden.converter.PlantConverter;
+import com.cotato.itda.domain.garden.dto.req.PlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import com.cotato.itda.domain.garden.entity.Plant;
+import com.cotato.itda.domain.garden.exception.PlantException;
+import com.cotato.itda.domain.garden.exception.code.PlantErrorCode;
+import com.cotato.itda.domain.garden.repository.PlantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlantCommandServiceImpl implements PlantCommandService {
+
+    private final PlantRepository plantRepository;
+
+    @Override
+    public PlantResDTO.CreatePlantResDTO createPlant(PlantReqDTO.CreatePlantReqDTO dto) {
+
+        if (plantRepository.existsByName(dto.name())) {
+            throw new PlantException(PlantErrorCode.DUPLICATE_NAME, Map.of("name", dto.name()));
+        }
+        Plant plant = PlantConverter.toPlant(dto);
+        plantRepository.save(plant);
+        return PlantConverter.toPlantCreateResDto(plant);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandService.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+
+public interface SharedPlantCommandService {
+    SharedPlantResDTO.WaterInfoResDTO waterPlant(Long sharedPlantId, SharedPlantReqDTO.WaterPlantReqDTO dto, Long memberId);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
@@ -1,0 +1,86 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.garden.converter.SharedPlantConverter;
+import com.cotato.itda.domain.garden.converter.SharedPlantLogConverter;
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantLog;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.garden.enums.SupplyType;
+import com.cotato.itda.domain.garden.exception.SharedPlantException;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.domain.garden.repository.SharedPlantLogRepository;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.garden.service.command.strategy.WateringStrategy;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.UserErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SharedPlantCommandServiceImpl implements SharedPlantCommandService {
+
+    private final List<WateringStrategy> wateringStrategies;
+    private final SharedPlantRepository sharedPlantRepository;
+    private final MemberRepository memberRepository;
+    private final SharedPlantLogRepository sharedPlantLogRepository;
+
+    @Override
+    public SharedPlantResDTO.WaterInfoResDTO waterPlant(Long sharedPlantId, SharedPlantReqDTO.WaterPlantReqDTO dto, Long memberId) {
+
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        SharedPlant sharedPlant = sharedPlantRepository.findById(sharedPlantId)
+                .orElseThrow(() -> new SharedPlantException(SharedPlantErrorCode.SHARED_PLANT_NOT_FOUND));
+
+        Long memberAId = sharedPlant.getMemberA().getId();
+        Long memberBId = sharedPlant.getMemberB().getId();
+        Long currentMemberId = currentMember.getId();
+
+        if (!(currentMemberId.equals(memberAId) || currentMemberId.equals(memberBId))) {
+            throw new SharedPlantException(SharedPlantErrorCode.NOT_A_PARTICIPANT);
+        }
+
+        if (sharedPlant.getStatus() == SharedPlantStatus.COMPLETED) {
+            throw new SharedPlantException(SharedPlantErrorCode.CANNOT_WATER_COMPLETED_PLANT);
+        }
+
+        if (sharedPlant.getIsSoloMode() && !sharedPlant.getSoloPowerMemberId().equals(currentMemberId)) {
+            sharedPlant.exitSoloMode();
+        }
+
+        int growthBefore = sharedPlant.getGrowthValue();
+
+        WateringStrategy strategy = wateringStrategies.stream()
+                .filter(s -> s.supports(sharedPlant, dto))
+                .findFirst()
+                .orElseThrow(() -> new SharedPlantException(SharedPlantErrorCode.NOT_FOUND_STRATEGY));
+
+        strategy.water(sharedPlant, currentMember, wateringStrategies);
+
+        int growthAfter = sharedPlant.getGrowthValue();
+        int growthIncrement = growthAfter - growthBefore;
+        boolean affectedGrowth = growthIncrement > 0;
+        boolean usedNutrient = dto.supplyType() == SupplyType.NUTRIENT;
+
+        SharedPlantLog log = SharedPlantLogConverter.toSharedPlantLog(
+                sharedPlant,
+                currentMember.getId(),
+                affectedGrowth,
+                growthIncrement,
+                usedNutrient
+        );
+
+        sharedPlantLogRepository.save(log);
+
+        return SharedPlantConverter.toWaterInfoResDTO(sharedPlant, currentMember);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
@@ -53,6 +53,11 @@ public class SharedPlantCommandServiceImpl implements SharedPlantCommandService 
             throw new SharedPlantException(SharedPlantErrorCode.CANNOT_WATER_COMPLETED_PLANT);
         }
 
+        boolean wasWithered = sharedPlant.getStatus() == SharedPlantStatus.WITHERED;
+        if (wasWithered && dto.supplyType() != SupplyType.NUTRIENT) {
+            throw new SharedPlantException(SharedPlantErrorCode.WITHERED_REQUIRES_NUTRIENT);
+        }
+
         if (sharedPlant.getIsSoloMode() && !sharedPlant.getSoloPowerMemberId().equals(currentMemberId)) {
             sharedPlant.exitSoloMode();
         }
@@ -65,6 +70,15 @@ public class SharedPlantCommandServiceImpl implements SharedPlantCommandService 
                 .orElseThrow(() -> new SharedPlantException(SharedPlantErrorCode.NOT_FOUND_STRATEGY));
 
         strategy.water(sharedPlant, currentMember, wateringStrategies);
+
+        if (wasWithered) {
+            sharedPlant.revive();
+        }
+
+        // 최대 성장 도달 시 COMPLETED 처리
+        if (sharedPlant.hasReachedMaxGrowth()) {
+            sharedPlant.complete();
+        }
 
         int growthAfter = sharedPlant.getGrowthValue();
         int growthIncrement = growthAfter - growthBefore;

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandService.java
@@ -1,0 +1,12 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.garden.dto.req.PlantInviteReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+
+public interface SharedPlantInviteCommandService {
+    PlantInviteResDTO.CreateSharedPlantInviteResDTO createInvite(Long inviterId,
+            PlantInviteReqDTO.CreateSharedPlantInviteReqDTO dto);
+
+    PlantInviteResDTO.UpdateSharedPlantInviteResDTO updateInviteStatus(Long inviteeId, Long inviteId,
+            PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
@@ -91,8 +91,10 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
     }
 
     @Override
-    public PlantInviteResDTO.UpdateSharedPlantInviteResDTO updateInviteStatus(Long inviteeId, Long inviteId,
-            PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto) {
+    public PlantInviteResDTO.UpdateSharedPlantInviteResDTO updateInviteStatus(
+            Long inviteeId, Long inviteId,
+            PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto
+    ) {
 
         // 1. 식물 초대 존재 여부 확인
         SharedPlantInvite invite = sharedPlantInviteRepository.findById(inviteId)
@@ -115,7 +117,7 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
 
         SharedPlant sharedPlant = null;
 
-        // 4. status가 ACCEPTED라면 현재 키우고 있는 식물이 있는지 확인 후 새 식물을 만들기
+        // 5. status가 ACCEPTED라면 현재 키우고 있는 식물이 있는지 확인 후 새 식물을 만들기
         if (dto.status() == InviteStatus.ACCEPTED) {
             // memberAId < memberBId
             Long memberAId = Math.min(invite.getInviter().getId(), invite.getInvitee().getId());

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
@@ -58,7 +58,7 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
                 .orElseThrow(() -> new PlantException(PlantErrorCode.NOT_FOUND));
 
         // 2. 두 유저가 활성 친구(ACTIVE) 상태인지 확인
-        if (!friendshipRepository.existsByMember_IdAndFriend_Id(inviterId, dto.inviteeId())) {
+        if (!friendshipRepository.existsByMemberIdAndFriendId(inviterId, dto.inviteeId())) {
             throw new FriendshipException(FriendshipErrorCode.NOT_ACTIVE);
         }
 

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
@@ -58,7 +58,7 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
                 .orElseThrow(() -> new PlantException(PlantErrorCode.NOT_FOUND));
 
         // 2. 두 유저가 활성 친구(ACTIVE) 상태인지 확인
-        if (!friendshipRepository.existsByMemberIdAndFriendId(inviterId, dto.inviteeId())) {
+        if (!friendshipRepository.existsByMember_IdAndFriend_Id(inviterId, dto.inviteeId())) {
             throw new FriendshipException(FriendshipErrorCode.NOT_ACTIVE);
         }
 

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
@@ -1,0 +1,137 @@
+package com.cotato.itda.domain.garden.service.command;
+
+import com.cotato.itda.domain.friendship.exception.FriendshipException;
+import com.cotato.itda.domain.friendship.exception.code.FriendshipErrorCode;
+import com.cotato.itda.domain.friendship.repository.FriendshipRepository;
+import com.cotato.itda.domain.garden.converter.SharedPlantConverter;
+import com.cotato.itda.domain.garden.converter.SharedPlantInviteConverter;
+import com.cotato.itda.domain.garden.dto.req.PlantInviteReqDTO;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+import com.cotato.itda.domain.garden.entity.Plant;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.garden.enums.InviteStatus;
+import com.cotato.itda.domain.garden.exception.PlantException;
+import com.cotato.itda.domain.garden.exception.SharedPlantException;
+import com.cotato.itda.domain.garden.exception.SharedPlantInviteException;
+import com.cotato.itda.domain.garden.exception.code.PlantErrorCode;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantInviteErrorCode;
+import com.cotato.itda.domain.garden.repository.PlantRepository;
+import com.cotato.itda.domain.garden.repository.SharedPlantInviteRepository;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.UserErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCommandService {
+
+    private final MemberRepository memberRepository;
+    private final PlantRepository plantRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final SharedPlantRepository sharedPlantRepository;
+    private final SharedPlantInviteRepository sharedPlantInviteRepository;
+
+    @Override
+    public PlantInviteResDTO.CreateSharedPlantInviteResDTO createInvite(Long inviterId,
+            PlantInviteReqDTO.CreateSharedPlantInviteReqDTO dto) {
+
+        if (inviterId.equals(dto.inviteeId())) {
+            throw new SharedPlantInviteException(SharedPlantInviteErrorCode.SELF_INVITE_NOT_ALLOWED);
+        }
+
+        // 1. 초대받는 유저 및 식물의 존재 여부 확인
+        Member inviter = memberRepository.findById(inviterId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Member invitee = memberRepository.findById(dto.inviteeId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Plant plant = plantRepository.findById(dto.plantId())
+                .orElseThrow(() -> new PlantException(PlantErrorCode.NOT_FOUND));
+
+        // 2. 두 유저가 활성 친구(ACTIVE) 상태인지 확인
+        if (!friendshipRepository.existsByMember_IdAndFriend_Id(inviterId, dto.inviteeId())) {
+            throw new FriendshipException(FriendshipErrorCode.NOT_ACTIVE);
+        }
+
+        // 3. 이미 대기 중인 초대(PENDING)가 있는지 확인
+        if (sharedPlantInviteRepository.existsPendingInviteBetween(inviterId, dto.inviteeId())) {
+            throw new SharedPlantInviteException(SharedPlantInviteErrorCode.ALREADY_HAS_PENDING_INVITE);
+        }
+
+        // 4. 이미 함께 키우는 중(GROWING, WITHERED)인지 확인
+        // memberAId < memberBId
+        Long memberAId = Math.min(inviterId, dto.inviteeId());
+        Long memberBId = Math.max(inviterId, dto.inviteeId());
+        if (sharedPlantRepository.existsGrowingOrWitheredBetween(memberAId, memberBId)) {
+            throw new SharedPlantException(SharedPlantErrorCode.ALREADY_HAS_SHARED_PLANT);
+        }
+
+        // 5. SharedPlantInvite 생성 및 저장
+        SharedPlantInvite invite = SharedPlantInvite.builder()
+                .inviter(inviter)
+                .invitee(invitee)
+                .plant(plant)
+                .nickname(dto.nickname())
+                .message(dto.message())
+                .status(InviteStatus.PENDING)
+                .build();
+
+        SharedPlantInvite savedInvite = sharedPlantInviteRepository.save(invite);
+
+        return SharedPlantInviteConverter.toCreateSharedPlantInviteResDTO(savedInvite);
+    }
+
+    @Override
+    public PlantInviteResDTO.UpdateSharedPlantInviteResDTO updateInviteStatus(Long inviteeId, Long inviteId,
+            PlantInviteReqDTO.UpdateSharedPlantInviteReqDTO dto) {
+
+        // 1. 식물 초대 존재 여부 확인
+        SharedPlantInvite invite = sharedPlantInviteRepository.findById(inviteId)
+                .orElseThrow(() -> new SharedPlantInviteException(SharedPlantInviteErrorCode.INVITE_NOT_FOUND));
+
+        // 2. 요청을 보낸 사람이 초대받은 사람인지 확인
+        if (!invite.getInvitee().getId().equals(inviteeId)) {
+            throw new SharedPlantInviteException(SharedPlantInviteErrorCode.NOT_INVITEE);
+        }
+
+        // 3. 초대 상태가 PENDING인지 확인
+        if (invite.getStatus() != InviteStatus.PENDING) {
+            throw new SharedPlantInviteException(SharedPlantInviteErrorCode.INVITE_NOT_PENDING);
+        }
+
+        // 4. 수락 혹은 거절 상태여야 함 (PENDING으로 다시 변경 불가)
+        if (dto.status() == InviteStatus.PENDING) {
+            throw new SharedPlantInviteException(SharedPlantInviteErrorCode.INVALID_INVITE_STATUS);
+        }
+
+        SharedPlant sharedPlant = null;
+
+        // 4. status가 ACCEPTED라면 현재 키우고 있는 식물이 있는지 확인 후 새 식물을 만들기
+        if (dto.status() == InviteStatus.ACCEPTED) {
+            // memberAId < memberBId
+            Long memberAId = Math.min(invite.getInviter().getId(), invite.getInvitee().getId());
+            Long memberBId = Math.max(invite.getInviter().getId(), invite.getInvitee().getId());
+
+            if (sharedPlantRepository.existsGrowingOrWitheredBetween(memberAId, memberBId)) {
+                throw new SharedPlantException(SharedPlantErrorCode.ALREADY_HAS_SHARED_PLANT);
+            }
+
+            sharedPlant = SharedPlantConverter.toSharedPlant(invite);
+
+            sharedPlantRepository.save(sharedPlant);
+        }
+
+        invite.updateStatus(dto.status());
+
+        return SharedPlantInviteConverter.toUpdateSharedPlantInviteResDTO(invite, sharedPlant);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/NutrientWateringStrategy.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/NutrientWateringStrategy.java
@@ -1,0 +1,78 @@
+package com.cotato.itda.domain.garden.service.command.strategy;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.GrowthType;
+import com.cotato.itda.domain.garden.enums.SupplyType;
+import com.cotato.itda.domain.garden.exception.SharedPlantException;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.domain.garden.repository.SharedPlantLogRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+public class NutrientWateringStrategy implements WateringStrategy {
+
+    private final SharedPlantLogRepository sharedPlantLogRepository;
+
+    public NutrientWateringStrategy(SharedPlantLogRepository sharedPlantLogRepository) {
+        this.sharedPlantLogRepository = sharedPlantLogRepository;
+    }
+
+    @Override
+    public boolean supports(SharedPlant sharedPlant, SharedPlantReqDTO.WaterPlantReqDTO dto) {
+        return dto.supplyType() == SupplyType.NUTRIENT;
+    }
+
+    @Override
+    public void water(SharedPlant sharedPlant, Member currentMember, List<WateringStrategy> allStrategies) {
+        WateringStrategy baseStrategy = findBaseStrategy(sharedPlant, allStrategies);
+
+        if (sharedPlant.getGrowthDate() != null) {
+            long daysSinceWatered = Math.max(0, ChronoUnit.DAYS.between(sharedPlant.getGrowthDate(), LocalDate.now()) - 1);
+            if (daysSinceWatered <= 1) {
+                throw new SharedPlantException(SharedPlantErrorCode.CANNOT_USE_NUTRIENT_YET);
+            }
+        }
+
+        if (currentMember.getNutrientCount() <= 0) {
+            throw new SharedPlantException(SharedPlantErrorCode.DONT_HAVE_NUTRIENT);
+        }
+
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+
+        boolean alreadyGaveNutrient = sharedPlantLogRepository.existsBySharedPlantAndWateredByAndUsedNutrientAndCreatedAtBetween(
+                sharedPlant,
+                currentMember.getId(),
+                true,
+                startOfDay,
+                endOfDay
+        );
+
+        if (alreadyGaveNutrient) {
+            throw new SharedPlantException(SharedPlantErrorCode.ALREADY_GAVE_NUTRIENT_TODAY);
+        }
+
+        baseStrategy.water(sharedPlant, currentMember, allStrategies);
+
+        sharedPlant.nutrient(GrowthType.NUTRIENT.getGrowth(), currentMember);
+    }
+
+    private WateringStrategy findBaseStrategy(SharedPlant sharedPlant, List<WateringStrategy> allStrategies) {
+
+        SharedPlantReqDTO.WaterPlantReqDTO dto = new SharedPlantReqDTO.WaterPlantReqDTO(SupplyType.WATER);
+
+        return allStrategies.stream()
+                .filter(strategy -> !(strategy instanceof NutrientWateringStrategy))
+                .filter(strategy -> strategy.supports(sharedPlant, dto))
+                .findFirst()
+                .orElseThrow(() -> new SharedPlantException(SharedPlantErrorCode.NOT_FOUND_STRATEGY));
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/SoloWateringStrategy.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/SoloWateringStrategy.java
@@ -1,0 +1,32 @@
+package com.cotato.itda.domain.garden.service.command.strategy;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.GrowthType;
+import com.cotato.itda.domain.garden.enums.SupplyType;
+import com.cotato.itda.domain.garden.exception.SharedPlantException;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class SoloWateringStrategy implements WateringStrategy {
+
+    @Override
+    public boolean supports(SharedPlant sharedPlant, SharedPlantReqDTO.WaterPlantReqDTO dto) {
+        return sharedPlant.getIsSoloMode() && dto.supplyType() == SupplyType.WATER;
+    }
+
+    @Override
+    public void water(SharedPlant sharedPlant, Member currentMember, List<WateringStrategy> allStrategies) {
+
+        if (sharedPlant.getGrowthDate().isEqual(LocalDate.now())) {
+            throw new SharedPlantException(SharedPlantErrorCode.ALREADY_WATERED);
+        }
+
+        sharedPlant.water(GrowthType.WATER.getGrowth(), currentMember, true);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/TeamWateringStrategy.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/TeamWateringStrategy.java
@@ -1,0 +1,50 @@
+package com.cotato.itda.domain.garden.service.command.strategy;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.GrowthType;
+import com.cotato.itda.domain.garden.enums.MaxGrowthCount;
+import com.cotato.itda.domain.garden.enums.SupplyType;
+import com.cotato.itda.domain.garden.exception.SharedPlantException;
+import com.cotato.itda.domain.garden.exception.code.SharedPlantErrorCode;
+import com.cotato.itda.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class TeamWateringStrategy implements WateringStrategy {
+
+    @Override
+    public boolean supports(SharedPlant sharedPlant, SharedPlantReqDTO.WaterPlantReqDTO dto) {
+        return !sharedPlant.getIsSoloMode() && dto.supplyType() == SupplyType.WATER;
+    }
+
+    @Override
+    public void water(SharedPlant sharedPlant, Member currentMember, List<WateringStrategy> allStrategies) {
+
+        if (sharedPlant.getLastWateredBy() == null && sharedPlant.getGrowthDate() == null) {
+            sharedPlant.water(GrowthType.WATER.getGrowth(), currentMember, true);
+            return;
+        }
+
+        if (sharedPlant.getLastWateredBy() != null && sharedPlant.getLastWateredBy().equals(currentMember.getId())) {
+            throw new SharedPlantException(SharedPlantErrorCode.CANNOT_WATER_CONSECUTIVELY);
+        }
+
+         if (sharedPlant.getGrowthDate().isEqual(LocalDate.now())) {
+            if (sharedPlant.getDailyGrowthCount() >= MaxGrowthCount.TEAM_GROW.getMaxGrowthCount()) {
+                throw new SharedPlantException(SharedPlantErrorCode.EXCEED_WATER_COUNT);
+            }
+
+            if (sharedPlant.getDailyGrowthCount() < MaxGrowthCount.TEAM_WATER.maxGrowthCount) {
+                sharedPlant.water(GrowthType.WATER.getGrowth(), currentMember, false);
+            } else {
+                sharedPlant.water(GrowthType.NONE.getGrowth(), currentMember, false);
+            }
+        } else {
+            sharedPlant.water(GrowthType.WATER.getGrowth(), currentMember, true);
+        }
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/WateringStrategy.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/strategy/WateringStrategy.java
@@ -1,0 +1,26 @@
+package com.cotato.itda.domain.garden.service.command.strategy;
+
+import com.cotato.itda.domain.garden.dto.req.SharedPlantReqDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface WateringStrategy {
+
+    /**
+     * 이 전략이 현재 요청을 처리해야 하는지 판단합니다.
+     * @param sharedPlant 대상 식물
+     * @param dto 요청 DTO
+     * @return 처리해야 하면 true
+     */
+    boolean supports(SharedPlant sharedPlant, SharedPlantReqDTO.WaterPlantReqDTO dto);
+
+    /**
+     * 실제 물 주기 또는 추가 기능 로직을 실행합니다.
+     * @param sharedPlant 대상 식물
+     * @param currentMember 요청한 회원
+     * @param allStrategies 데코레이터가 기본 전략을 찾기 위해 필요한 모든 전략 리스트
+     */
+    void water(SharedPlant sharedPlant, Member currentMember, List<WateringStrategy> allStrategies);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/PlantQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/PlantQueryService.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import org.springframework.data.domain.Sort;
+
+public interface PlantQueryService {
+    PlantResDTO.PlantListResDto getPlantList(Sort sort);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/PlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/PlantQueryServiceImpl.java
@@ -1,0 +1,42 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.garden.converter.PlantConverter;
+import com.cotato.itda.domain.garden.dto.res.PlantResDTO;
+import com.cotato.itda.domain.garden.entity.Plant;
+import com.cotato.itda.domain.garden.repository.PlantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlantQueryServiceImpl implements PlantQueryService {
+
+    private final PlantRepository plantRepository;
+
+    @Override
+    public PlantResDTO.PlantListResDto getPlantList(Sort sort) {
+        List<Plant> plants;
+
+        if (sort != null && sort.isSorted()) {
+            Sort.Order difficultyOrder = sort.getOrderFor("difficulty");
+            if (difficultyOrder != null) {
+                if (difficultyOrder.isAscending()) {
+                    plants = plantRepository.findAllOrderByDifficultyAsc();
+                } else {
+                    plants = plantRepository.findAllOrderByDifficultyDesc();
+                }
+            } else {
+                plants = plantRepository.findAll(sort);
+            }
+        } else {
+            plants = plantRepository.findAll(Sort.unsorted());
+        }
+
+        return PlantConverter.toPlantListResDto(plants);
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryService.java
@@ -1,0 +1,9 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+
+public interface SharedPlantInviteQueryService {
+    PlantInviteResDTO.PlantInviteCandidatesResDto getInviteCandidates(Long memberId);
+
+    PlantInviteResDTO.MyPlantInviteListResDTO getMyPendingInvitations(Long memberId);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
@@ -34,7 +34,7 @@ public class SharedPlantInviteQueryServiceImpl implements SharedPlantInviteQuery
         public PlantInviteResDTO.PlantInviteCandidatesResDto getInviteCandidates(Long memberId) {
 
                 // 1. friendship 도메인에서 ACTIVE 상태인 친구 목록 및 ID 가져오기
-                List<Friendship> totalFriends = friendshipRepository.findAllByMember_IdAndStatus(
+                List<Friendship> totalFriends = friendshipRepository.findAllByMemberIdAndStatus(
                                 memberId, FriendshipStatus.ACTIVE,
                                 Sort.by(Sort.Direction.DESC, "lastInteractedAt"));
 
@@ -78,7 +78,7 @@ public class SharedPlantInviteQueryServiceImpl implements SharedPlantInviteQuery
                                 .distinct()
                                 .toList();
 
-                List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
+                List<Friendship> friendships = friendshipRepository.findAllByMemberIdAndFriendIdInAndStatus(
                                 memberId, inviterIds, FriendshipStatus.ACTIVE);
 
                 return SharedPlantInviteConverter.toMyPlantInviteListResDTO(invitations, friendships);

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
@@ -78,7 +78,7 @@ public class SharedPlantInviteQueryServiceImpl implements SharedPlantInviteQuery
                                 .distinct()
                                 .toList();
 
-                List<Friendship> friendships = friendshipRepository.findAllByMemberIdAndFriendIdInAndStatus(
+                List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
                                 memberId, inviterIds, FriendshipStatus.ACTIVE);
 
                 return SharedPlantInviteConverter.toMyPlantInviteListResDTO(invitations, friendships);

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantInviteQueryServiceImpl.java
@@ -1,0 +1,86 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.friendship.entity.Friendship;
+import com.cotato.itda.domain.friendship.enums.FriendshipStatus;
+import com.cotato.itda.domain.friendship.repository.FriendshipRepository;
+import com.cotato.itda.domain.garden.dto.res.PlantInviteResDTO;
+import com.cotato.itda.domain.garden.repository.SharedPlantInviteRepository;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.garden.converter.SharedPlantInviteConverter;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.garden.enums.InviteStatus;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.UserErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SharedPlantInviteQueryServiceImpl implements SharedPlantInviteQueryService {
+
+        private final FriendshipRepository friendshipRepository;
+        private final SharedPlantRepository sharedPlantRepository;
+        private final SharedPlantInviteRepository sharedPlantInviteRepository;
+        private final MemberRepository memberRepository;
+
+        @Override
+        public PlantInviteResDTO.PlantInviteCandidatesResDto getInviteCandidates(Long memberId) {
+
+                // 1. friendship 도메인에서 ACTIVE 상태인 친구 목록 및 ID 가져오기
+                List<Friendship> totalFriends = friendshipRepository.findAllByMember_IdAndStatus(
+                                memberId, FriendshipStatus.ACTIVE,
+                                Sort.by(Sort.Direction.DESC, "lastInteractedAt"));
+
+                // 2. shared_plant 도메인에서 현재 나와 GROWING, WITHERED 상태의 shared_plant가 있는 친구 ID 목록
+                // 조회
+                List<Long> growingFriendIds = sharedPlantRepository
+                                .findGrowingOrWitheredSharedPlantFriendIds(memberId);
+
+                // 3. shared_plant_invite 테이블에서 현재 나와 PENDING 상태인 친구 ID 목록 조회
+                List<Long> pendingInviteFriendIds = sharedPlantInviteRepository.findPendingInviteFriendIds(memberId);
+
+                // 4. 전체 친구 리스트에서 2번과 3번 ID를 제외 (차집합) + 멤버 상태가 ACTIVE인 경우만
+                List<Friendship> filteredFriends = totalFriends.stream()
+                                .filter(friendship -> friendship.getFriend().getStatus() == MemberStatus.ACTIVE)
+                                .filter(friendship -> !growingFriendIds.contains(friendship.getFriend().getId()))
+                                .filter(friendship -> !pendingInviteFriendIds.contains(friendship.getFriend().getId()))
+                                .toList();
+
+                return SharedPlantInviteConverter.toPlantInviteCandidatesResDto(filteredFriends);
+        }
+
+        @Override
+        public PlantInviteResDTO.MyPlantInviteListResDTO getMyPendingInvitations(Long memberId) {
+
+                // 0. 사용자 존재 여부 확인
+                if (!memberRepository.existsById(memberId)) {
+                        throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                }
+
+                // 1. 내가 받은 PENDING 상태의 초대 목록 내림차순 조회 (오래된 순)
+                List<SharedPlantInvite> invitations = sharedPlantInviteRepository
+                                .findAllByInviteeIdAndStatusOrderByCreatedAtAsc(memberId, InviteStatus.PENDING);
+
+                if (invitations.isEmpty()) {
+                        return SharedPlantInviteConverter.toMyPlantInviteListResDTO(invitations, List.of());
+                }
+
+                // 2. 초대자들의 표시 이름(DisplayName)을 가져오기 위해 필요한 친구 관계만 조회
+                List<Long> inviterIds = invitations.stream()
+                                .map(invite -> invite.getInviter().getId())
+                                .distinct()
+                                .toList();
+
+                List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
+                                memberId, inviterIds, FriendshipStatus.ACTIVE);
+
+                return SharedPlantInviteConverter.toMyPlantInviteListResDTO(invitations, friendships);
+        }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryService.java
@@ -1,0 +1,10 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+
+import java.util.List;
+
+public interface SharedPlantQueryService {
+    SharedPlantResDTO.SharedPlantInfoListDTO getSharedPlants(Long memberId, List<SharedPlantStatus> statuses);
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -1,0 +1,75 @@
+package com.cotato.itda.domain.garden.service.query;
+
+import com.cotato.itda.domain.friendship.entity.Friendship;
+import com.cotato.itda.domain.friendship.enums.FriendshipStatus;
+import com.cotato.itda.domain.friendship.repository.FriendshipRepository;
+import com.cotato.itda.domain.garden.converter.SharedPlantConverter;
+import com.cotato.itda.domain.garden.dto.SharedPlantWithFriendship;
+import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.UserErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
+
+    private final SharedPlantRepository sharedPlantRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public SharedPlantResDTO.SharedPlantInfoListDTO getSharedPlants(Long memberId, List<SharedPlantStatus> statuses) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 1. 상태에 해당하는 공유 식물 조회
+        List<SharedPlant> sharedPlants = sharedPlantRepository.findAllByMemberIdAndStatusIn(memberId, statuses);
+
+        if (sharedPlants.isEmpty()) {
+            return SharedPlantResDTO.SharedPlantInfoListDTO.builder()
+                    .totalCount(0)
+                    .nutrientCount(member.getNutrientCount())
+                    .sharedPlants(List.of())
+                    .build();
+        }
+
+        // 2. 각 공유 식물에서 친구 ID 추출
+        List<Long> friendIds = sharedPlants.stream()
+                .map(sp -> sp.getMemberA().getId().equals(memberId)
+                        ? sp.getMemberB().getId()
+                        : sp.getMemberA().getId())
+                .toList();
+
+        // 3. Friendship 조회 후 Map으로 변환
+        List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
+                memberId, friendIds, FriendshipStatus.ACTIVE);
+
+        Map<Long, Friendship> friendshipMap = friendships.stream()
+                .collect(Collectors.toMap(Friendship::getFriendId, f -> f));
+
+        // 4. SharedPlant와 Friendship 짝짓기
+        List<SharedPlantWithFriendship> pairs = sharedPlants.stream()
+                .map(sp -> {
+                    Long friendId = sp.getMemberA().getId().equals(memberId)
+                            ? sp.getMemberB().getId()
+                            : sp.getMemberA().getId();
+                    return new SharedPlantWithFriendship(sp, friendshipMap.get(friendId));
+                })
+                .toList();
+
+        return SharedPlantConverter.toSharedPlantInfoListDTO(pairs, member.getNutrientCount());
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -7,7 +7,9 @@ import com.cotato.itda.domain.garden.converter.SharedPlantConverter;
 import com.cotato.itda.domain.garden.dto.SharedPlantWithFriendship;
 import com.cotato.itda.domain.garden.dto.res.SharedPlantResDTO;
 import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantLog;
 import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.garden.repository.SharedPlantLogRepository;
 import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +30,7 @@ import java.util.stream.Collectors;
 public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
 
     private final SharedPlantRepository sharedPlantRepository;
+    private final SharedPlantLogRepository sharedPlantLogRepository;
     private final FriendshipRepository friendshipRepository;
     private final MemberRepository memberRepository;
 
@@ -70,6 +74,20 @@ public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
                 })
                 .toList();
 
-        return SharedPlantConverter.toSharedPlantInfoListDTO(pairs, member.getNutrientCount(), memberId);
+        // 5. 현재 멤버의 마지막 물주기 시간 조회
+        List<Long> sharedPlantIds = sharedPlants.stream()
+                .map(SharedPlant::getId)
+                .toList();
+
+        List<SharedPlantLog> latestLogs = sharedPlantLogRepository.findLatestLogsBySharedPlantIdsAndMemberId(
+                sharedPlantIds, memberId);
+
+        Map<Long, LocalDateTime> myLastWateredAtMap = latestLogs.stream()
+                .collect(Collectors.toMap(
+                        log -> log.getSharedPlant().getId(),
+                        SharedPlantLog::getWateredAt
+                ));
+
+        return SharedPlantConverter.toSharedPlantInfoListDTO(pairs, member.getNutrientCount(), memberId, myLastWateredAtMap);
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -70,6 +70,6 @@ public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
                 })
                 .toList();
 
-        return SharedPlantConverter.toSharedPlantInfoListDTO(pairs, member.getNutrientCount());
+        return SharedPlantConverter.toSharedPlantInfoListDTO(pairs, member.getNutrientCount(), memberId);
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -58,7 +58,7 @@ public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
                 .toList();
 
         // 3. Friendship 조회 후 Map으로 변환
-        List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
+        List<Friendship> friendships = friendshipRepository.findAllByMemberIdAndFriendIdInAndStatus(
                 memberId, friendIds, FriendshipStatus.ACTIVE);
 
         Map<Long, Friendship> friendshipMap = friendships.stream()

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -58,7 +58,7 @@ public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
                 .toList();
 
         // 3. Friendship 조회 후 Map으로 변환
-        List<Friendship> friendships = friendshipRepository.findAllByMemberIdAndFriendIdInAndStatus(
+        List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
                 memberId, friendIds, FriendshipStatus.ACTIVE);
 
         Map<Long, Friendship> friendshipMap = friendships.stream()

--- a/src/main/java/com/cotato/itda/domain/member/entity/Member.java
+++ b/src/main/java/com/cotato/itda/domain/member/entity/Member.java
@@ -130,4 +130,8 @@ public class Member extends BaseTimeEntity {
 			this.points = this.points % 10;
 		}
 	}
+
+	public void decreaseNutrient() {
+		this.nutrientCount--;
+	}
 }

--- a/src/main/java/com/cotato/itda/domain/signup/service/SignupPasswordService.java
+++ b/src/main/java/com/cotato/itda/domain/signup/service/SignupPasswordService.java
@@ -47,15 +47,14 @@ public class SignupPasswordService {
 
 	@Transactional
 	public SubmitPasswordResponse submit(
-		String draftKey,
-		SubmitPasswordRequest request
-	) {
+			String draftKey,
+			SubmitPasswordRequest request) {
 		// 1. Draft 조회
 		SignupDraftRedisValue draft = signupDraftRedisRepository.findByDraftKey(draftKey)
-			.orElseThrow(() -> new BusinessException(SignupErrorCode.SIGNUP_DRAFT_NOT_FOUND));
+				.orElseThrow(() -> new BusinessException(SignupErrorCode.SIGNUP_DRAFT_NOT_FOUND));
 		log.info("레디스 에서 조회된 Signup Draft: {}", draft);
 
-		//2. step 검증 + 멱등 처리
+		// 2. step 검증 + 멱등 처리
 		// - 이미 COMPLETED인데 Step6이 재호출 될 수 있다(타임아웃/재시도)
 		// - 이 경우, 회원 재생성 하면 안 됨
 		// - 대신 기존 회원을 찾아 토큰만 새로 발급해서 내려준다.
@@ -64,11 +63,11 @@ public class SignupPasswordService {
 
 			String phone = requireOtpPhone(draft);
 
-			Long memberId = memberRepository.findByPhoneNumber(phone)
-				.orElseThrow(() -> new BusinessException(SignupErrorCode.MEMBER_NOT_FOUND))
-				.getId();
+			Member member = memberRepository.findByPhoneNumber(phone)
+					.orElseThrow(() -> new BusinessException(SignupErrorCode.MEMBER_NOT_FOUND));
+			Long memberId = member.getId();
 
-			IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(memberId, "ROLE_USER");
+			IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(memberId, member.getRole().name());
 			if (issuedAccessToken == null) {
 				throw new BusinessException(SignupErrorCode.TOKEN_ISSUANCE_FAILED);
 			}
@@ -120,20 +119,18 @@ public class SignupPasswordService {
 		try {
 			// 7. 회원 생성 및 저장
 			Member saved = memberRepository.save(
-				Member.createLocalMember(
-					phone,
-					name,
-					birthDate,
-					MemberRole.USER,
-					null,
-					passwordHash
-				)
-			);
+					Member.createLocalMember(
+							phone,
+							name,
+							birthDate,
+							MemberRole.USER,
+							null,
+							passwordHash));
 			log.info("신규 회원 생성 및 저장 완료: {}", saved);
 
 			// 번들 기준으로 약관 아이템 전체를 조회
 			List<TermsItemEntity> items = termsItemJpaRepository
-				.findActiveByBundle(draft.policy().bundleType(), draft.policy().bundleVersion());
+					.findActiveByBundle(draft.policy().bundleType(), draft.policy().bundleVersion());
 			if (items.isEmpty()) {
 				throw new BusinessException(SignupErrorCode.INVALID_TERMS_BUNDLE_PARAMETERS);
 			}
@@ -141,23 +138,22 @@ public class SignupPasswordService {
 
 			// 8. 약관 동의 기록 저장
 			List<MemberTermsConsentEntity> consentEntities = draft.terms().consents().stream()
-				.map(consent -> MemberTermsConsentEntity.create(
-					saved.getId(),
-					consent.id(),
-					consent.agreed()
-				))
-				.toList();
+					.map(consent -> MemberTermsConsentEntity.create(
+							saved.getId(),
+							consent.id(),
+							consent.agreed()))
+					.toList();
 			memberTermsConsentRepository.saveAll(consentEntities);
 			log.info("약관 동의 기록 저장 완료: {}개", consentEntities.size());
 
 			// 9. 액세스 토큰/리프레시 토큰 발급
-			IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(saved.getId(), "ROLE_USER");
+			IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(saved.getId(), saved.getRole().name());
 			IssuedToken issuedRefreshToken = jwtTokenProvider.createRefreshToken(saved.getId());
 			log.info("액세스 토큰 및 리프레시 토큰 발급 완료");
-			log.info("Access Token: {}", ((IssuedAccessToken)issuedAccessToken).token());
-			log.info("Refresh Token: {}", ((IssuedRefreshToken)issuedRefreshToken).token());
+			log.info("Access Token: {}", ((IssuedAccessToken) issuedAccessToken).token());
+			log.info("Refresh Token: {}", ((IssuedRefreshToken) issuedRefreshToken).token());
 
-			// 10.  Draft COMPLETED로 전이(비밀번호는 저장하지 않음)
+			// 10. Draft COMPLETED로 전이(비밀번호는 저장하지 않음)
 			SignupDraftRedisValue completed = draft.onSignupCompleted();
 			log.info("Signup Draft 상태 COMPLETED로 전이 완료");
 			signupDraftRedisRepository.updatePreserveTtl(completed);
@@ -172,20 +168,17 @@ public class SignupPasswordService {
 	}
 
 	private SubmitPasswordResponse toResponse(Long memberId, IssuedToken issuedAccessToken,
-		IssuedToken issuedRefreshToken) {
+			IssuedToken issuedRefreshToken) {
 		return new SubmitPasswordResponse(
-			SignupStep.COMPLETED.name(),
-			memberId,
-			new Tokens(
-				new Tokens.AccessTokenOnly(
-					issuedAccessToken.token(),
-					issuedAccessToken.expiresAt()
-				),
-				new Tokens.RefreshTokenOnly(
-					issuedRefreshToken.token(),
-					issuedRefreshToken.expiresAt()
-				)
-			)
+				SignupStep.COMPLETED.name(),
+				memberId,
+				new Tokens(
+						new Tokens.AccessTokenOnly(
+								issuedAccessToken.token(),
+								issuedAccessToken.expiresAt()),
+						new Tokens.RefreshTokenOnly(
+								issuedRefreshToken.token(),
+								issuedRefreshToken.expiresAt()))
 
 		);
 	}
@@ -233,7 +226,7 @@ public class SignupPasswordService {
 		// 3) 공백 포함 여부 체크
 		// =========================
 		// - 공백이 들어가면 사용자가 "보이는 문자열"과 "실제 입력"이 달라질 수 있어
-		//   로그인 실패/혼란을 유발하기 쉽다.
+		// 로그인 실패/혼란을 유발하기 쉽다.
 		// - 그래서 애초에 공백을 금지하는 정책
 		if (password.contains(" ")) {
 			throw new BusinessException(SignupErrorCode.INVALID_PASSWORD_POLICY);
@@ -245,9 +238,7 @@ public class SignupPasswordService {
 
 		// 4-1) 영문(ASCII) 포함 여부
 		// - ASCII 영문자(A~Z, a~z)만 true로 인정하도록 범위를 체크한다.
-		boolean hasLetter = password.chars().anyMatch(ch ->
-			(ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
-		);
+		boolean hasLetter = password.chars().anyMatch(ch -> (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'));
 
 		// 4-2) ASCII 숫자만 포함 여부
 		// - 여기서는 '0'~'9' 사이 문자가 하나라도 있는지 확인한다.
@@ -255,8 +246,7 @@ public class SignupPasswordService {
 
 		// 4-3) 특수문자 포함 여부
 		boolean hasSpecial = password.chars().anyMatch(
-			ch -> "!@#$%^&*()_+-=[]{};':\",.<>/?\\|`~".indexOf(ch) >= 0
-		);
+				ch -> "!@#$%^&*()_+-=[]{};':\",.<>/?\\|`~".indexOf(ch) >= 0);
 
 		// =========================
 		// 5) "종류" 카운트 후 최소 2종 이상 요구

--- a/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
@@ -124,6 +124,16 @@ public class SwaggerConfig {
                 .build();
     }
 
+    @Bean
+    public GroupedOpenApi GardenApi() {
+        return GroupedOpenApi.builder()
+                .group("Garden")
+                .displayName("Garden API")
+                .packagesToScan("com.cotato.itda.domain.garden.controller")
+                .pathsToMatch("/api/plants/**", "/api/plant-invites/**")
+                .build();
+    }
+
     // === 공통 에러 응답 자동 추가 (선택) ===
     @Bean
     public OperationCustomizer addGlobalResponses() {

--- a/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
@@ -130,7 +130,7 @@ public class SwaggerConfig {
                 .group("Garden")
                 .displayName("Garden API")
                 .packagesToScan("com.cotato.itda.domain.garden.controller")
-                .pathsToMatch("/api/plants/**", "/api/plant-invites/**")
+                .pathsToMatch("/api/plants/**", "/api/plant-invites/**", "/api/shared-plants/**")
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#51 

## 📝작업 내용

- 정원 도메인의 핵심 기능인 공동 돌봄 식물 기능을 구현했습니다.
- 전략 패턴과 데코레이터 패턴을 적용하여 물 주기 로직을 구현했습니다.
- 주요 구현 사항
  1. 공동 돌봄 식물 관리 (`SharedPlant`)
    - 공동 돌봄 식물 목록 및 상세 정보 조회 API 구현
    - `SharedPlant` (공동 식물), `SharedPlantLog` (활동 로그) 엔티티 설계

  2. 공동 돌봄 친구 초대 (`SharedPlantInvite`)
    - 친구에게 공동 식물 키우기 초대 전송, 수락, 거절 API 구현
    - `InviteStatus` Enum을 통해 초대 상태 관리

  3. 식물 물주기 및 영양제 시스템 (`waterPlant` API)
    - 식물 돌보기의 핵심 로직인 `waterPlant` API를 구현했습니다.
    - **전략 패턴**을 활용하여 아래와 같이 돌봄 모드별 로직을 분리했습니다.
      - `SoloWateringStrategy`: 혼자 돌보기 모드 로직
      - `TeamWateringStrategy`: 함께 돌보기 모드 로직
    - **데코레이터 패턴** 원리를 활용하여 영양제 사용 로직을 구현했습니다.
      - `NutrientWateringStrategy`: 기본 물주기 기능에 영양제 효과(추가 성장, 영양제 차감 등)를 덧붙입니다.
    - 아래와 같은 다양한 비즈니스 규칙을 검증 로직에 포함했습니다.
      - **(팀 모드)** 참가자 확인, 연속 돌봄 불가, 일일 물주기 횟수 제한
      - **(솔로 모드)** 일일 물주기 횟수 제한, 다른 멤버 참여 시 팀 모드 자동 전환
      - **(영양제)** 물과 함께 사용, 멤버별/식물별 일일 사용 횟수 제한, 특정 조건 (2일 이상 미급수)에서만 사용 가능

  4. 기타
    - 정원 도메인 관련 Controller, DTO, Converter, Repository 등 구성 요소 추가
    - 비즈니스 규칙에 따른 예외 처리 로직 구현

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 
<img width="635" height="582" alt="image" src="https://github.com/user-attachments/assets/fe4bd86d-8db7-45ce-8f46-7ae0c6066c50" />

## 💬리뷰 요구사항 

- 물주기 및 영양제 사용의 핵심 로직은 `WateringStrategy` 인터페이스의 구현체들과 이를 사용하는 `SharedPlantCommandService`에 집중되어 있습니다. 다양한 비즈니스 규칙이 정확하게 반영되었는지 중심적으로 확인 부탁드립니다.
- `lastWateredAt`을 기준으로 식물이 시들거나, 4일 이상 활동이 없을 때 혼자 돌봄 모드로 전환되는 로직은 추후 스케쥴러를 통해 별도로 구현될 예정입니다.
- 아래의 테스트케이스들을 통과하였으나, 추가로 고려해야할 테스트케이스가 있다면 피드백 부탁드립니다.
  1. 첫 물주기 (성공)
  2. 두 번째 물주기 - 다른 사람 (성공)
  3. 같은 사람 연속 물주기 (실패)
  4. 하루 3~4번째 물주기 (성공, 성장값 증가 없음)
  5. 하루 5번째 물주기 (실패)
  6. 영양제 - 1일 미급수 전 사용 (실패)
  7. 영양제 - 2일 이상 미급수 후 사용 (성공)
  8. 영양제 미보유 시 사용 (실패)
  9. 같은 날 영양제 2번 사용 시도 (실패)
  10. 참여자가 아닌 사람의 물주기 (실패)
  11. 완료된 식물에 물주기 (실패)
  12. 솔로 모드 - 권한 있는 멤버 물주기 (성공)
  13. 솔로 모드 - 상대방 물주기로 복귀 (성공)