### PR TITLE
feat 채팅방 메시지 전송 및 받기 기능 구현 

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
@@ -5,13 +5,18 @@ import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cotato.itda.domain.chat.controller.dto.ChatMessageSliceResponse;
 import com.cotato.itda.domain.chat.controller.dto.ChatRoomSliceResponse;
+import com.cotato.itda.domain.chat.controller.dto.DirectRoomResolveResponse;
 import com.cotato.itda.domain.chat.exception.code.ChatErrorCode;
+import com.cotato.itda.domain.chat.service.ChatMessageService;
 import com.cotato.itda.domain.chat.service.ChatRoomService;
+import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 
@@ -25,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomController {
 
 	private final ChatRoomService chatRoomService;
-
+	private final ChatMessageService chatMessageService;
 	/**
 	 * GET /api/chat/rooms?cursorAt=2026-02-02T14:30:15.123&cursorRoomId=50&limit=20
 	 * -> 사용자가 속한 채팅방들을 커서 기반 페이지네이션으로 조회
@@ -34,7 +39,7 @@ public class ChatRoomController {
 	 */
 	@Operation(summary = "내 채팅방 목록 조회 (커서 페이지네이션)", description = "내가 속한 채팅방 목록을 커서 기반 페이지네이션으로 조회합니다.")
 	@GetMapping()
-	public ChatRoomSliceResponse getMyRooms(
+	public ApiResponse<ChatRoomSliceResponse> getMyRooms(
 		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
 
 		@Parameter(description = "페이지 크기 (기본 10, 최대 20)", example = "10")
@@ -62,11 +67,50 @@ public class ChatRoomController {
 			throw new BusinessException(ChatErrorCode.INVALID_CURSOR);
 		}
 		Long memberId = jwtPrincipal.memberId();
-		return chatRoomService.getMyRooms(
+		ChatRoomSliceResponse response= chatRoomService.getMyRooms(
 			memberId,
 			limit,
 			cursorAt,
 			cursorRoomId
 		);
+		return ApiResponse.success(response);
+	}
+
+	@Operation(
+		summary = "DIRECT 방 존재 여부 resolve",
+		description = """
+			친구 선택 후 채팅 화면 진입 전에 호출.
+			exists=true면 roomId로 /topic/chat/rooms/{roomId} 구독 + 히스토리 로딩.
+			exists=false면 임시 화면(roomId 없음) 진입 후 첫 SEND에서 방 생성.
+		"""
+	)
+	@GetMapping("/direct/resolve")
+	public ApiResponse<DirectRoomResolveResponse> resolveDirectRoom(
+		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@RequestParam Long opponentMemberId
+	) {
+		Long memberId = jwtPrincipal.memberId();
+		DirectRoomResolveResponse response = chatRoomService.resolveDirectRoom(memberId, opponentMemberId);
+		return ApiResponse.success(response);
+	}
+
+	@Operation(
+		summary = "채팅 히스토리 조회(커서 페이지네이션)",
+		description = """
+			- roomId가 있는 채팅 화면에서 HTTP로 과거 메시지를 로딩하는 API
+			- cursorSeq가 null이면 최신부터
+			- cursorSeq가 있으면 message_seq < cursorSeq로 과거로 내려감
+		"""
+	)
+	@GetMapping("/{roomId}/messages")
+	public ApiResponse<ChatMessageSliceResponse> getRoomMessages(
+		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@PathVariable Long roomId,
+		@RequestParam(required = false) Integer limit,
+		@RequestParam(required = false) Long cursorSeq
+	) {
+		Long memberId = jwtPrincipal.memberId();
+		ChatMessageSliceResponse response = chatMessageService.getRoomMessages(memberId, roomId, limit, cursorSeq);
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageItemDto.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageItemDto.java
@@ -1,0 +1,58 @@
+package com.cotato.itda.domain.chat.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.cotato.itda.domain.chat.enums.AttachmentStatus;
+import com.cotato.itda.domain.chat.enums.AttachmentType;
+import com.cotato.itda.domain.chat.enums.MessageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ChatMessageItemDto(
+	@Schema(description = "메시지 ID", example = "9001")
+	Long messageId,
+
+	@Schema(description = "방 내 seq", example = "31")
+	long messageSeq,
+
+	@Schema(description = "보낸 사람 ID", example = "10")
+	Long senderMemberId,
+
+	@Schema(description = "메시지 타입(TEXT/ATTACHMENT)", example = "TEXT")
+	MessageType messageType,
+
+	@Schema(description = "텍스트 내용(첨부만이면 null 가능)", example = "안녕!")
+	String content,
+
+	@Schema(description = "전송 시각", example = "2026-02-03T18:10:12.123")
+	LocalDateTime createdAt,
+
+	@Schema(description = "첨부 메타(없으면 null)")
+	AttachmentMeta attachment
+) {
+	/**
+	 * 첨부 메타(voice/image/file 공통)
+	 */
+	@Builder
+	public record AttachmentMeta(
+		@Schema(description = "첨부 타입", example = "IMAGE")
+		AttachmentType attachmentType,
+
+		@Schema(description = "S3 object key", example = "attachments/2026/02/03/uuid.png")
+		String objectKey,
+
+		@Schema(description = "mime type", example = "image/png")
+		String mimeType,
+
+		@Schema(description = "파일 크기(bytes)", example = "842133")
+		Long sizeBytes,
+
+		@Schema(description = "업로드 상태", example = "READY")
+		AttachmentStatus status,
+
+		@Schema(description = "음성 길이(ms) - 음성이 아니면 null", example = "4300")
+		Integer durationMs
+	) {}
+}

--- a/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageSliceResponse.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageSliceResponse.java
@@ -1,0 +1,22 @@
+package com.cotato.itda.domain.chat.controller.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+/**
+ * 히스토리 커서 페이지네이션
+ * - cursorSeq 기준으로 과거로 내려가는 방식
+ */
+@Builder
+public record ChatMessageSliceResponse (
+	@Schema(description = "메시지 목록(최신 -> 과거순)")
+	List<ChatMessageItemDto> items,
+
+	@Schema(description = "다음 페이지 존재 여부")
+	boolean hasNext,
+
+	@Schema(description= "다음 커서(message_seq). 다음 요청에서 cursorSeq로 넘김", nullable = true)
+	Long nextCursorSeq
+) {}

--- a/src/main/java/com/cotato/itda/domain/chat/controller/dto/DirectRoomResolveResponse.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/dto/DirectRoomResolveResponse.java
@@ -1,0 +1,16 @@
+package com.cotato.itda.domain.chat.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DIRECT 방 존재 여부 resolve 결과
+ */
+public record DirectRoomResolveResponse(
+
+	@Schema(description = "방 존재 여부", example="true")
+	boolean exists,
+
+	@Schema(description = "존재하는 경우 해당 방 ID(없으면 null)", example = "42", nullable = true)
+	Long roomId
+) {
+}

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoom.java
@@ -60,10 +60,28 @@ public class ChatRoom extends BaseTimeEntity {
 	@Column(name = "room_type", nullable = false, length = 20)
 	private RoomType roomType;
 
+	@Column(name = "direct_member_low_id")
+	private Long directMemberLowId;
+
+	@Column(name = "direct_member_high_id")
+	private Long directMemberHighId;
+
 	@Builder
-	private ChatRoom(String roomName, RoomType roomType) {
+	private ChatRoom(String roomName, RoomType roomType, Long directMemberLowId, Long directMemberHighId) {
+		this.directMemberLowId = directMemberLowId;
+		this.directMemberHighId = directMemberHighId;
 		this.roomName = roomName;
 		this.roomType = roomType;
+	}
+
+	public static ChatRoom createDirectRoom(Long myId, Long opponentId) {
+		Long lowId = Math.min(myId, opponentId);
+		Long highId = Math.max(myId, opponentId);
+		return ChatRoom.builder()
+			.roomType(RoomType.DIRECT)
+			.directMemberLowId(lowId)
+			.directMemberHighId(highId)
+			.build();
 	}
 
 	public void updateLastMessageCache(

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -121,6 +121,7 @@ public class ChatRoomMember extends BaseTimeEntity {
 	}
 
 	// 읽음 처리
+	// 내가 메시지를 읽었거나/ 내가 보낸 메시지는 자동 읽음 처리해야 함
 	// readSeq: 읽은 메시지의 시퀀스 번호
 	// readMessageId: 읽은 메시지의 ID
 	public void markRead(long readSeq, Long readMesssageId) {

--- a/src/main/java/com/cotato/itda/domain/chat/enums/LastMessageType.java
+++ b/src/main/java/com/cotato/itda/domain/chat/enums/LastMessageType.java
@@ -4,5 +4,6 @@ public enum LastMessageType {
 	TEXT,
 	IMAGE,
 	VOICE,
-	FILE
+	FILE,
+	ATTACHMENT
 }

--- a/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
@@ -11,6 +11,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatErrorCode implements ErrorCode {
 
+	INVALID_REQUEST_BOTH_ROOMID_OPPONENTID_NULL(
+		HttpStatus.BAD_REQUEST,
+		"roomId와 opponentMemberId가 모두 null일 수 없습니다.",
+		"CHAT_ERROR_400_INVALID_REQUEST_BOTH_ROOMID_OPPONENTID_NULL"
+	),
 	INVALID_CURSOR(
 		HttpStatus.BAD_REQUEST,
 		"잘못된 커서입니다.",

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessasgeAttachmentRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessasgeAttachmentRepository.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cotato.itda.domain.chat.entity.ChatMessageAttachment;
+
+public interface ChatMessasgeAttachmentRepository extends JpaRepository<ChatMessageAttachment,Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,56 @@
+package com.cotato.itda.domain.chat.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.cotato.itda.domain.chat.entity.ChatRoomMember;
+import com.cotato.itda.domain.chat.enums.MemberRoomStatus;
+
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
+
+	// 특정 방에 특정 멤버가 특정 상태로 참여 중인지 확인
+	// ex: 이 사용자가 이 방에 ACTIVE로  속해 있나?
+	@Query("""
+		    select crm
+		    from ChatRoomMember crm
+		    where crm.room.id = :roomId
+		      and crm.member.id = :memberId
+		      and crm.status = :status
+		""")
+	Optional<ChatRoomMember> findOneByRoomMemberStatus(
+		@Param("roomId") Long roomId,
+		@Param("memberId") Long memberId,
+		@Param("status") MemberRoomStatus status
+	);
+
+	// 특정 roomId의 멤버 중 내가 아닌 멤버(상대)를 찾는 쿼리
+	// DIRECT에서만 사용
+	@Query("""
+			select crm.member.id
+			from ChatRoomMember crm
+			where crm.room.id = :roomId
+				and crm.member.id <> :myMemberId
+				and crm.status = :status
+		""")
+	Optional<Long> findOpponentMemberId(
+		@Param("roomId") Long roomId,
+		@Param("myMemberId") Long myMemberId,
+		@Param("status") MemberRoomStatus status
+	);
+
+	@Query("""
+			select crm.room.id
+			from ChatRoomMember crm
+			where crm.member.id = :memberId
+			  and crm.status = :status
+			  and crm.room.id in :roomIds
+		""")
+	List<Long> findActiveRoomIdsIn(Long memberId,
+		@Param("status") MemberRoomStatus status,
+		@Param("roomIds") List<Long> roomIds
+	);
+}

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
@@ -2,12 +2,17 @@ package com.cotato.itda.domain.chat.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.cotato.itda.domain.chat.entity.QChatMessage;
+import com.cotato.itda.domain.chat.entity.QChatMessageAttachment;
 import com.cotato.itda.domain.chat.entity.QChatRoom;
 import com.cotato.itda.domain.chat.entity.QChatRoomMember;
 import com.cotato.itda.domain.chat.enums.MemberRoomStatus;
+import com.cotato.itda.domain.chat.enums.RoomType;
+import com.cotato.itda.domain.chat.repository.dto.MessageRow;
 import com.cotato.itda.domain.chat.repository.dto.MyRoomRow;
 import com.cotato.itda.domain.chat.repository.dto.OpponentRow;
 import com.cotato.itda.domain.member.entity.QMember;
@@ -126,6 +131,93 @@ public class ChatRoomQueryRepository {
 					.and(chatRoomMember.member.id.ne(myMemberId))
 					.and(chatRoomMember.status.eq(MemberRoomStatus.ACTIVE))
 			)
+			.fetch();
+	}
+
+	/**
+	 * DIRECT 방 resolve
+	 * - ACTIVE 상태인 멤버십이 둘 다 있어야 함
+	 * - 없으면 Optional.empty()
+	 * 빠르게 활성화된 멤버 둘 다 있는지 확인 후 방 ID 리턴
+	 */
+	public Optional<Long> resolveDirectRoomId(Long myMemberId, Long opponentMemberId) {
+		long low = Math.min(myMemberId, opponentMemberId);
+		long high = Math.max(myMemberId, opponentMemberId);
+
+		QChatRoom cr = QChatRoom.chatRoom;
+		QChatRoomMember m1 = QChatRoomMember.chatRoomMember;
+		QChatRoomMember m2 = new QChatRoomMember("m2");
+
+		Long roomId = queryFactory
+			.select(cr.id)
+			.from(cr)
+			// 방 타입은 DIRECT만
+			.where(
+				cr.roomType.eq(RoomType.DIRECT),
+				cr.directMemberLowId.eq(low),
+				cr.directMemberHighId.eq(high)
+			)
+			// 내 membership
+			.join(m1).on(m1.room.eq(cr))
+			// 상대 membership (같은 room)
+			.join(m2).on(m2.room.eq(cr))
+			.where(
+				m1.member.id.eq(myMemberId),
+				m1.status.eq(MemberRoomStatus.ACTIVE),
+				m2.member.id.eq(opponentMemberId),
+				m2.status.eq(MemberRoomStatus.ACTIVE)
+			)
+			.fetchFirst();
+
+		return Optional.ofNullable(roomId);
+	}
+
+	/**
+	 * 히스토리 조회 ( 커서 기반)
+	 * - cursorSeq가 null이면 최신부터
+	 * - cursorSeq가 있으면 message_seq < cursorSeq (더 과거로)
+	 * - limit+1로 hasNext 판정
+	 */
+	public List<MessageRow> findRoomMessagesSlice(
+		Long roomId,
+		Long cursorSeq,
+		int limitPlusOne
+	){
+		QChatMessage m = QChatMessage.chatMessage;
+		QChatMessageAttachment a = QChatMessageAttachment.chatMessageAttachment;
+
+		BooleanBuilder where = new BooleanBuilder();
+		where.and(m.room.id.eq(roomId));
+		where.and(m.deletedAt.isNull());
+
+		// cursorSeq가 있으면 where 조건 추가
+		// 더 과거 메시지로
+		if(cursorSeq!=null){
+			where.and(m.messageSeq.lt(cursorSeq));
+		}
+
+		return queryFactory
+			.select(Projections.constructor(
+				MessageRow.class,
+				m.id,
+				m.messageSeq,
+				m.sender.id,
+				m.messageType,
+				m.content,
+				m.createdAt,
+
+				a.attachmentType,
+				a.objectKey,
+				a.mimeType,
+				a.sizeBytes,
+				a.status,
+				a.durationMs
+			))
+			.from(m)
+			.leftJoin(a).on(a.message.eq(m))
+			.where(where)
+			.orderBy(m.messageSeq.desc())
+			.limit(limitPlusOne)
 			.fetch();
 	}
 

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,39 @@
+package com.cotato.itda.domain.chat.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.cotato.itda.domain.chat.entity.ChatRoom;
+import com.cotato.itda.domain.chat.enums.RoomType;
+
+import jakarta.persistence.LockModeType;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+	/**
+	 * message_seq를 안전하게  증가시키려면 room row를 잠그고(lastMessageSeq 기반) 다음 seq를 계산해야 한다
+	 * - 비관적 락(PESSIMISTIC_WRITE): 동시에 여러 SEND 요청이 들어와도 seq가 꼬이지 않게 막아줌
+	 */
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select r from ChatRoom r where r.id= :roomId")
+	Optional<ChatRoom> findByIdForUpdate(Long roomId);
+
+	// ChatRoom을 JPQL로 조회하기 위한 Repository 메서드
+	// 목적: DIRECT(1:1) 채팅방이 이미 존재하는지 확인(Resolve)해서,
+	//       있으면 기존 방을 재사용하고, 없으면 새로 만들 때 사용한다.
+	@Query("""
+		select r
+		from ChatRoom r
+		where r.roomType = :roomType
+		and r.directMemberLowId = :directMemberLowId
+		and r.directMemberHighId = :directMemberHighId
+		""")
+	Optional<ChatRoom> findByRoomTypeAndDirectMemberLowIdAndDirectMemberHighId(
+		@Param("roomType") RoomType roomType,                 // 방 타입 (보통 DIRECT)
+		@Param("directMemberLowId") Long directMemberLowId,   // 두 멤버 중 더 작은 id (min)
+		@Param("directMemberHighId") Long directMemberHighId  // 두 멤버 중 더 큰 id (max)
+	);
+}

--- a/src/main/java/com/cotato/itda/domain/chat/repository/dto/ChatMessageRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/dto/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.chat.repository.dto;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cotato.itda.domain.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
+}

--- a/src/main/java/com/cotato/itda/domain/chat/repository/dto/MessageRow.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/dto/MessageRow.java
@@ -1,0 +1,27 @@
+package com.cotato.itda.domain.chat.repository.dto;
+
+import java.time.LocalDateTime;
+
+import com.cotato.itda.domain.chat.enums.AttachmentStatus;
+import com.cotato.itda.domain.chat.enums.AttachmentType;
+import com.cotato.itda.domain.chat.enums.MessageType;
+
+/**
+ * 히스토리 조회용 row (메시지 + 첨부 join)
+ * - attachment는 없을 수 있으니 nullable
+ */
+public record MessageRow (
+	long messageId,
+	long messageSeq,
+	Long senderId,
+	MessageType messageType,
+	String content,
+	LocalDateTime createdAt,
+
+	AttachmentType attachmentType,
+	String objectKey,
+	String mimeType,
+	Long sizeBytes,
+	AttachmentStatus attachmentStatus,
+	Integer durationMs
+	){}

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,369 @@
+
+package com.cotato.itda.domain.chat.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.chat.controller.dto.ChatMessageItemDto;
+import com.cotato.itda.domain.chat.controller.dto.ChatMessageSliceResponse;
+import com.cotato.itda.domain.chat.entity.ChatMessage;
+import com.cotato.itda.domain.chat.entity.ChatRoom;
+import com.cotato.itda.domain.chat.entity.ChatRoomMember;
+import com.cotato.itda.domain.chat.enums.LastMessageType;
+import com.cotato.itda.domain.chat.enums.MemberRoomStatus;
+import com.cotato.itda.domain.chat.enums.MessageType;
+import com.cotato.itda.domain.chat.exception.code.ChatErrorCode;
+import com.cotato.itda.domain.chat.repository.ChatRoomMemberRepository;
+import com.cotato.itda.domain.chat.repository.ChatRoomQueryRepository;
+import com.cotato.itda.domain.chat.repository.ChatRoomRepository;
+import com.cotato.itda.domain.chat.repository.dto.ChatMessageRepository;
+import com.cotato.itda.domain.chat.repository.dto.MessageRow;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.websocket.dto.ChatEventEnvelope;
+import com.cotato.itda.domain.websocket.dto.ChatEventType;
+import com.cotato.itda.domain.websocket.dto.ChatRoomMessageDto;
+import com.cotato.itda.domain.websocket.dto.ChatSendMessageRequest;
+import com.cotato.itda.domain.websocket.dto.RoomCreatedData;
+import com.cotato.itda.domain.websocket.dto.RoomListUpdatedData;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomQueryRepository chatRoomQueryRepository;
+
+	private final MemberRepository memberRepository;
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Transactional
+	public void sendMessage(Long senderMemberId, ChatSendMessageRequest req) {
+
+		// ===== [0] 요청 들어옴 =====
+		log.info(
+			"[채팅 SEND 시작] senderMemberId={}, req.roomId={}, req.opponentMemberId={}, req.messageType={}, contentLen={}",
+			senderMemberId,
+			req.roomId(),
+			req.opponentMemberId(),
+			req.messageType(),
+			(req.content() == null ? 0 : req.content().length())
+		);
+
+		// 요청 검증: roomId, opponentMemberId 둘 다 null 불가
+		if (req.roomId() == null && req.opponentMemberId() == null) {
+			log.warn("[채팅 SEND 거절] roomId/opponentMemberId 둘 다 null 입니다. senderMemberId={}", senderMemberId);
+			throw new BusinessException(ChatErrorCode.INVALID_REQUEST_BOTH_ROOMID_OPPONENTID_NULL);
+		}
+
+		// ===== [1] 발신자 조회 =====
+		log.info("[발신자 조회] senderMemberId={} 조회 시작", senderMemberId);
+		Member sender = memberRepository.findById(senderMemberId)
+			.orElseThrow(() -> {
+				log.warn("[발신자 조회 실패] senderMemberId={} 없음", senderMemberId);
+				return new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND);
+			});
+		log.info("[발신자 조회 완료] senderMemberId={}, nicknameOrId={}",
+			senderMemberId,
+			sender.getId()
+		);
+
+		// ===== [2] 채팅방 조회 or 생성 =====
+		boolean isRoomCreatedNow = false;
+
+		Long roomId = req.roomId();
+		Long opponentMemberId = req.opponentMemberId();
+
+		log.info("[방 결정 시작] 입력 roomId={}, opponentMemberId={}", roomId, opponentMemberId);
+
+		if (roomId == null) {
+			log.info("[방 resolve 시작] senderMemberId={}, opponentMemberId={}", senderMemberId, opponentMemberId);
+
+			// ⚠️ 버그 포인트: 지금 코드는 orElseGet 결과(기존방/신규방)를 구분하지 못해서 isRoomCreatedNow=true로 고정됨
+			// 아래 로그로 실제로 새로 만든 건지 확인 가능하게 분기 로그를 넣는다.
+			Long resolvedRoomId = chatRoomQueryRepository.resolveDirectRoomId(senderMemberId, opponentMemberId)
+				.orElse(null);
+
+			if (resolvedRoomId != null) {
+				roomId = resolvedRoomId;
+				isRoomCreatedNow = false;
+				log.info("[방 resolve 성공] 기존 방 발견. roomId={}", roomId);
+			} else {
+				log.info("[방 resolve 실패] 기존 방 없음 -> 신규 방 생성 시작");
+
+				ChatRoom newRoom = chatRoomRepository.save(
+					ChatRoom.createDirectRoom(senderMemberId, opponentMemberId)
+				);
+
+				roomId = newRoom.getId();
+				isRoomCreatedNow = true;
+
+				log.info("[신규 방 생성 완료] roomId={}", roomId);
+
+				Member opponent = memberRepository.findById(opponentMemberId)
+					.orElseThrow(() -> {
+						log.warn("[상대 조회 실패] opponentMemberId={} 없음 (방 생성 중)", opponentMemberId);
+						return new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND);
+					});
+
+				chatRoomMemberRepository.save(ChatRoomMember.create(sender, newRoom));
+				chatRoomMemberRepository.save(ChatRoomMember.create(opponent, newRoom));
+
+				log.info("[방 멤버십 생성 완료] roomId={}, senderMemberId={}, opponentMemberId={}",
+					roomId, senderMemberId, opponentMemberId
+				);
+			}
+		} else {
+			log.info("[방 결정 완료] 요청에 roomId 포함. roomId={}", roomId);
+		}
+
+		// ===== [3] 권한 체크 =====
+		log.info("[권한 체크] senderMemberId={} 가 roomId={} ACTIVE 멤버인지 확인", senderMemberId, roomId);
+
+		final Long lockedRoomId = roomId; // 람다 내에서 사용하기 위한 final 변수
+		ChatRoomMember myMembership = chatRoomMemberRepository
+			.findOneByRoomMemberStatus(roomId, senderMemberId, MemberRoomStatus.ACTIVE)
+			.orElseThrow(() -> {
+				log.warn("[권한 체크 실패] senderMemberId={} 는 roomId={} ACTIVE 멤버가 아님", senderMemberId, lockedRoomId);
+				return new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
+			});
+
+		log.info("[권한 체크 성공] senderMemberId={} 는 roomId={} ACTIVE 멤버", senderMemberId, roomId);
+
+		// ===== [4] seq 발급 + 메시지 저장 (비관적 락) =====
+		log.info("[방 row 락 획득 시도] roomId={}", roomId);
+
+		ChatRoom room = chatRoomRepository.findByIdForUpdate(roomId)
+			.orElseThrow(() -> {
+				log.warn("[방 조회 실패] roomId={} 없음", lockedRoomId);
+				return new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
+			});
+
+		Long lastMessageSeq = room.getLastMessageSeq();
+		long lastSeq = (lastMessageSeq == null) ? 0L : lastMessageSeq;
+		long nextSeq = lastSeq + 1;
+
+		log.info("[seq 발급] roomId={}, lastSeq={}, nextSeq={}", roomId, lastSeq, nextSeq);
+
+		ChatMessage message = ChatMessage.createChatMessage(
+			sender,
+			room,
+			nextSeq,
+			req.messageType(),
+			req.content()
+		);
+
+		chatMessageRepository.save(message);
+		log.info("[메시지 저장 완료] roomId={}, messageId={}, messageSeq={}, senderMemberId={}, messageType={}",
+			roomId, message.getId(), message.getMessageSeq(), senderMemberId, req.messageType()
+		);
+
+		// ===== [5] 내 메시지 자동 읽음 처리 =====
+		myMembership.markRead(nextSeq, message.getId());
+		log.info("[읽음 처리] senderMemberId={} 가 보낸 메시지 자동 읽음 처리. roomId={}, readSeq={}, readMessageId={}",
+			senderMemberId, roomId, nextSeq, message.getId()
+		);
+
+		// ===== [6] room last_message 갱신 =====
+		LastMessageType lastType = switch (req.messageType()) {
+			case TEXT -> LastMessageType.TEXT;
+			case ATTACHMENT -> LastMessageType.ATTACHMENT;
+		};
+
+		String preview = (req.content() == null || req.content().isBlank())
+			? (req.messageType() == MessageType.ATTACHMENT ? "[첨부파일]" : "")
+			: req.content();
+
+		LocalDateTime now = LocalDateTime.now();
+
+		room.updateLastMessageCache(
+			message.getId(),
+			nextSeq,
+			now,
+			preview,
+			lastType
+		);
+
+		log.info("[방 캐시 갱신] roomId={}, lastMessageId={}, lastMessageSeq={}, lastMessageAt={}, lastType={}, preview={}",
+			roomId, message.getId(), nextSeq, now, lastType, preview
+		);
+
+		// ===== [7] 상대 ID 추출 =====
+		Long opponentId = chatRoomMemberRepository
+			.findOpponentMemberId(roomId, senderMemberId, MemberRoomStatus.ACTIVE)
+			.orElse(null);
+
+		log.info("[상대 조회] roomId={}, senderMemberId={}, opponentId={}",
+			roomId, senderMemberId, opponentId
+		);
+
+		// ===== [8] 방 토픽 발행 =====
+		ChatRoomMessageDto roomMessageDto = ChatRoomMessageDto.builder()
+			.roomId(roomId)
+			.messageId(message.getId())
+			.messageSeq(message.getMessageSeq())
+			.senderMemberId(senderMemberId)
+			.messageType(req.messageType())
+			.content(req.content())
+			.createdAt(now)
+			.attachment(null)
+			.build();
+
+		String roomTopicDest = "/topic/chat/rooms/" + roomId;
+
+		messagingTemplate.convertAndSend(roomTopicDest, roomMessageDto);
+		log.info("[방 토픽 발행] dest={}, roomId={}, messageId={}, messageSeq={}",
+			roomTopicDest, roomId, message.getId(), nextSeq
+		);
+
+		// ===== [9] 개인 큐 이벤트 발행 =====
+		String userQueueDest = "/queue/chat/events";
+
+		// 9-1. 방을 방금 만든 경우: sender에게 ROOM_CREATED
+		if (isRoomCreatedNow) {
+			ChatEventEnvelope<RoomCreatedData> created = ChatEventEnvelope.<RoomCreatedData>builder()
+				.type(ChatEventType.ROOM_CREATED)
+				.roomId(roomId)
+				.opponentMemberId(opponentMemberId)
+				.eventAt(now)
+				.data(RoomCreatedData.builder()
+					.firstMessageId(message.getId())
+					.firstMessageSeq(nextSeq)
+					.lastMessagePreview(preview)
+					.build())
+				.build();
+
+			messagingTemplate.convertAndSendToUser(
+				String.valueOf(senderMemberId),
+				userQueueDest,
+				created
+			);
+
+			log.info(
+				"[개인 이벤트 발행] (ROOM_CREATED) toUser={}, dest=/user{}, roomId={}, opponentMemberId={}, firstMessageId={}, firstSeq={}",
+				senderMemberId, userQueueDest, roomId, opponentMemberId, message.getId(), nextSeq
+			);
+		} else {
+			log.info("[ROOM_CREATED 생략] 이번 요청은 신규 방 생성이 아님. roomId={}", roomId);
+		}
+
+		// 9-2. 목록 갱신 이벤트는 sender/상대에게 발행
+		ChatEventEnvelope<RoomListUpdatedData> listUpdated = ChatEventEnvelope.<RoomListUpdatedData>builder()
+			.type(ChatEventType.ROOM_LIST_UPDATED)
+			.roomId(roomId)
+			.opponentMemberId(opponentId)
+			.eventAt(now)
+			.data(RoomListUpdatedData.builder()
+				.lastMessagePreview(preview)
+				.lastMessageType(lastType)
+				.lastMessageAt(now)
+				.lastMessageSeq(nextSeq)
+				.lastMessageId(message.getId())
+				.build())
+			.build();
+
+		messagingTemplate.convertAndSendToUser(
+			String.valueOf(senderMemberId),
+			userQueueDest,
+			listUpdated
+		);
+
+		log.info("[개인 이벤트 발행] (ROOM_LIST_UPDATED) toUser={}, dest=/user{}, roomId={}, lastMessageId={}, lastSeq={}",
+			senderMemberId, userQueueDest, roomId, message.getId(), nextSeq
+		);
+
+		if (opponentId != null) {
+			messagingTemplate.convertAndSendToUser(
+				String.valueOf(opponentId),
+				userQueueDest,
+				listUpdated
+			);
+
+			log.info("[개인 이벤트 발행] (ROOM_LIST_UPDATED) toUser={}, dest=/user{}, roomId={}, lastMessageId={}, lastSeq={}",
+				opponentId, userQueueDest, roomId, message.getId(), nextSeq
+			);
+		} else {
+			log.warn("[상대 없음] 1:1방에서 상대가 나갔거나 ACTIVE 아님. roomId={}, senderMemberId={}", roomId, senderMemberId);
+		}
+
+		log.info("[채팅 SEND 완료] senderMemberId={}, roomId={}, messageId={}, messageSeq={}, isRoomCreatedNow={}",
+			senderMemberId, roomId, message.getId(), nextSeq, isRoomCreatedNow
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public ChatMessageSliceResponse getRoomMessages(Long memberId, Long roomId, Integer limit, Long cursorSeq) {
+
+		log.info("[채팅 히스토리 조회 시작] memberId={}, roomId={}, limit={}, cursorSeq={}",
+			memberId, roomId, limit, cursorSeq
+		);
+
+		// 권한 체크
+		chatRoomMemberRepository
+			.findOneByRoomMemberStatus(roomId, memberId, MemberRoomStatus.ACTIVE)
+			.orElseThrow(() -> {
+				log.warn("[히스토리 권한 실패] memberId={} 는 roomId={} ACTIVE 멤버 아님", memberId, roomId);
+				return new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
+			});
+
+		int safeLimit = (limit == null) ? 30 : Math.min(Math.max(limit, 1), 100);
+		int limitPlusOne = safeLimit + 1;
+
+		log.info("[히스토리 조회 파라미터] safeLimit={}, limitPlusOne={}, cursorSeq={}", safeLimit, limitPlusOne, cursorSeq);
+
+		List<MessageRow> fetched = chatRoomQueryRepository.findRoomMessagesSlice(roomId, cursorSeq, limitPlusOne);
+
+		boolean hasNext = fetched.size() > safeLimit;
+		List<MessageRow> page = hasNext ? fetched.subList(0, safeLimit) : fetched;
+
+		log.info("[히스토리 조회 결과] roomId={}, fetchedSize={}, pageSize={}, hasNext={}",
+			roomId, fetched.size(), page.size(), hasNext
+		);
+
+		List<ChatMessageItemDto> items = page.stream()
+			.map(row -> ChatMessageItemDto.builder()
+				.messageId(row.messageId())
+				.messageSeq(row.messageSeq())
+				.senderMemberId(row.senderId())
+				.messageType(row.messageType())
+				.content(row.content())
+				.createdAt(row.createdAt())
+				.attachment(row.attachmentType() == null ? null : ChatMessageItemDto.AttachmentMeta.builder()
+					.attachmentType(row.attachmentType())
+					.objectKey(row.objectKey())
+					.mimeType(row.mimeType())
+					.sizeBytes(row.sizeBytes())
+					.status(row.attachmentStatus())
+					.durationMs(row.durationMs())
+					.build())
+				.build())
+			.toList();
+
+		Long nextCursor = null;
+		if (hasNext && !page.isEmpty()) {
+			nextCursor = page.get(page.size() - 1).messageSeq();
+		}
+
+		log.info("[채팅 히스토리 조회 완료] roomId={}, itemsSize={}, nextCursorSeq={}",
+			roomId, items.size(), nextCursor
+		);
+
+		return ChatMessageSliceResponse.builder()
+			.items(items)
+			.hasNext(hasNext)
+			.nextCursorSeq(nextCursor)
+			.build();
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.itda.domain.chat.controller.dto.ChatRoomListItemDto;
 import com.cotato.itda.domain.chat.controller.dto.ChatRoomSliceResponse;
+import com.cotato.itda.domain.chat.controller.dto.DirectRoomResolveResponse;
 import com.cotato.itda.domain.chat.controller.dto.OpponentSummaryDto;
 import com.cotato.itda.domain.chat.enums.RoomType;
 import com.cotato.itda.domain.chat.repository.ChatRoomQueryRepository;
@@ -17,10 +18,12 @@ import com.cotato.itda.domain.chat.repository.dto.MyRoomRow;
 import com.cotato.itda.domain.chat.repository.dto.OpponentRow;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ChatRoomService {
 	private final ChatRoomQueryRepository chatRoomQueryRepository;
 
@@ -30,10 +33,19 @@ public class ChatRoomService {
 		LocalDateTime cursorAt,
 		Long cursorRoomId
 	) {
+		// ===== [0] 요청 파라미터 로그 =====
 		int safeLimit = (limit == null) ? 10 : Math.min(Math.max(limit, 1), 20);
 		int limitPlusOne = safeLimit + 1;
 
-		// 1) limit+1로 조회해서 Slice 판정 준비
+		log.info("[내 채팅방 목록 조회 시작] memberId={}, limit={}, safeLimit={}, cursorAt={}, cursorRoomId={}",
+			memberId, limit, safeLimit, cursorAt, cursorRoomId
+		);
+
+		// ===== [1] limit+1 조회 =====
+		log.info("[내 채팅방 목록 조회] findMyRoomsSlice 호출 -> memberId={}, cursorAt={}, cursorRoomId={}, limitPlusOne={}",
+			memberId, cursorAt, cursorRoomId, limitPlusOne
+		);
+
 		List<MyRoomRow> fetched = chatRoomQueryRepository.findMyRoomsSlice(
 			memberId,
 			cursorAt,
@@ -41,43 +53,84 @@ public class ChatRoomService {
 			limitPlusOne
 		);
 
-		// 2) Slice 판정
-		//   limit+1개가 조회되었으면 다음 페이지가 있다는 뜻
-		boolean hasNext = fetched.size() > safeLimit;
+		log.info("[내 채팅방 목록 조회 결과] fetchedSize={}", fetched.size());
 
-		// hasNext 면 마지막 1개는 버림
+		// ===== [2] Slice 판정 =====
+		boolean hasNext = fetched.size() > safeLimit;
 		List<MyRoomRow> page = hasNext ? fetched.subList(0, safeLimit) : fetched;
 
-		// 3) DIRECT 방만 상대 정보 조회(N+1 문제 방지)
+		log.info("[Slice 판정] hasNext={}, pageSize={}, safeLimit={}", hasNext, page.size(), safeLimit);
+
+		if (!page.isEmpty()) {
+			MyRoomRow first = page.get(0);
+			MyRoomRow last = page.get(page.size() - 1);
+			log.info("[페이지 범위] 첫번째 roomId={}, lastMessageAt={}, 마지막 roomId={}, lastMessageAt={}",
+				first.roomId(), first.lastMessageAt(), last.roomId(), last.lastMessageAt()
+			);
+		}
+
+		// ===== [3] DIRECT 방 상대 정보 조회 준비 =====
 		List<Long> directRoomIds = page.stream()
 			.filter(r -> r.roomType() == RoomType.DIRECT)
 			.map(MyRoomRow::roomId)
 			.toList();
 
-		Map<Long, OpponentSummaryDto> opponentMap = chatRoomQueryRepository
-			.findOpponentsInDirectRooms(memberId, directRoomIds)
-			.stream()
-			.collect(Collectors.toMap(
-				OpponentRow::roomId,
-				row -> OpponentSummaryDto.builder()
-					.memberId(row.memberId())
-					.name(row.name())
-					.profileImageUrl(row.profileImageUrl())
-					.build(),
-				// DIRECT는 방당 1명만 기대하지만 ,혹시 중복이 나오면 첫 번째 유지
-				(a, b) -> a
-			));
+		log.info("[DIRECT 방 추출] memberId={}, directRoomCount={}, directRoomIds={}",
+			memberId, directRoomIds.size(), directRoomIds
+		);
 
-		// 4) unread_count 계산 + 응답 DTO 조립
+		Map<Long, OpponentSummaryDto> opponentMap;
+
+		if (directRoomIds.isEmpty()) {
+			opponentMap = Map.of();
+			log.info("[DIRECT 상대 조회 스킵] directRoomIds 비어있음");
+		} else {
+			log.info("[DIRECT 상대 조회] findOpponentsInDirectRooms 호출 -> memberId={}, directRoomIds={}",
+				memberId, directRoomIds
+			);
+
+			List<OpponentRow> opponentRows =
+				chatRoomQueryRepository.findOpponentsInDirectRooms(memberId, directRoomIds);
+
+			log.info("[DIRECT 상대 조회 결과] opponentRowsSize={}", opponentRows.size());
+
+			opponentMap = opponentRows.stream()
+				.collect(Collectors.toMap(
+					OpponentRow::roomId,
+					row -> OpponentSummaryDto.builder()
+						.memberId(row.memberId())
+						.name(row.name())
+						.profileImageUrl(row.profileImageUrl())
+						.build(),
+					(a, b) -> a
+				));
+
+			// 어떤 방에 상대가 매핑됐는지 확인용(디버깅 때 매우 도움됨)
+			log.info("[DIRECT 상대 매핑 완료] opponentMapKeys(roomIds)={}", opponentMap.keySet());
+		}
+
+		// ===== [4] unread_count 계산 + DTO 조립 =====
 		List<ChatRoomListItemDto> items = page.stream()
 			.map(row -> {
-				// effectiveReadSeq: 내가 읽은 마지막 메세지 시퀀스 = max(last_read_seq, join_seq)
 				long effectiveReadSeq = Math.max(row.lastReadSeq(), row.joinSeq());
-
-				// lastMessageSeq가 null이면 0으로 간주
 				long lastMessageSeq = (row.lastMessageSeq() == null) ? 0L : row.lastMessageSeq();
-
 				long unread = Math.max(0L, lastMessageSeq - effectiveReadSeq);
+
+				OpponentSummaryDto opp = (row.roomType() == RoomType.DIRECT)
+					? opponentMap.get(row.roomId())
+					: null;
+
+				// 각 row마다 핵심값 로그 (너무 많으면 INFO가 과하니, 필요하면 DEBUG로 내려도 됨)
+				log.info("[방 아이템 계산] roomId={}, roomType={}, lastMessageSeq={}, lastReadSeq={}, joinSeq={}, effectiveReadSeq={}, unread={}, opponentMemberId={}",
+					row.roomId(),
+					row.roomType(),
+					row.lastMessageSeq(),
+					row.lastReadSeq(),
+					row.joinSeq(),
+					effectiveReadSeq,
+					unread,
+					(opp == null ? null : opp.memberId())
+				);
 
 				return ChatRoomListItemDto.builder()
 					.roomId(row.roomId())
@@ -89,21 +142,30 @@ public class ChatRoomService {
 					.lastMessagePreview(row.lastMessagePreview())
 					.lastMessageType(row.lastMessageType())
 					.unreadCount(unread)
-					.opponent(row.roomType() == RoomType.DIRECT ? opponentMap.get(row.roomId()) : null)
+					.opponent(row.roomType() == RoomType.DIRECT ? opp : null)
 					.build();
 			})
 			.toList();
 
-		// 5) nextCursor 생성
+		log.info("[내 채팅방 목록 DTO 조립 완료] itemsSize={}, hasNext={}", items.size(), hasNext);
+
+		// ===== [5] nextCursor 생성 =====
 		LocalDateTime nextCursorAt = null;
 		Long nextCursorRoomId = null;
 
 		if (hasNext && !items.isEmpty()) {
-			// 이번 페이지의 마지막 아이템이 다음 페이지의 커서
 			ChatRoomListItemDto last = items.get(items.size() - 1);
 			nextCursorAt = last.lastMessageAt();
 			nextCursorRoomId = last.roomId();
+
+			log.info("[다음 커서 생성] nextCursorAt={}, nextCursorRoomId={}", nextCursorAt, nextCursorRoomId);
+		} else {
+			log.info("[다음 커서 없음] hasNext={}, itemsEmpty={}", hasNext, items.isEmpty());
 		}
+
+		log.info("[내 채팅방 목록 조회 완료] memberId={}, itemsSize={}, hasNext={}, nextCursorAt={}, nextCursorRoomId={}",
+			memberId, items.size(), hasNext, nextCursorAt, nextCursorRoomId
+		);
 
 		return ChatRoomSliceResponse.builder()
 			.items(items)
@@ -111,5 +173,30 @@ public class ChatRoomService {
 			.nextCursorAt(nextCursorAt)
 			.nextCursorRoomId(nextCursorRoomId)
 			.build();
+	}
+
+	/**
+	 *
+	 * GET /api/chat/rooms/direct/resolve?opponentMemberId=...
+	 * - 방이 있으면 exists=true + roomId
+	 * - 없으면 exists=false + null
+	 */
+	public DirectRoomResolveResponse resolveDirectRoom(Long myMemberId, Long opponentMemberId){
+
+		log.info("[DIRECT 방 resolve 시작] myMemberId={}, opponentMemberId={}", myMemberId, opponentMemberId);
+
+		return chatRoomQueryRepository.resolveDirectRoomId(myMemberId, opponentMemberId)
+			.map(roomId -> {
+				log.info("[DIRECT 방 resolve 성공] myMemberId={}, opponentMemberId={}, roomId={}",
+					myMemberId, opponentMemberId, roomId
+				);
+				return new DirectRoomResolveResponse(true, roomId);
+			})
+			.orElseGet(() -> {
+				log.info("[DIRECT 방 resolve 실패] myMemberId={}, opponentMemberId={} -> 방 없음",
+					myMemberId, opponentMemberId
+				);
+				return new DirectRoomResolveResponse(false, null);
+			});
 	}
 }

--- a/src/main/java/com/cotato/itda/domain/websocket/controller/ChatMessageWsController.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/controller/ChatMessageWsController.java
@@ -1,0 +1,73 @@
+package com.cotato.itda.domain.websocket.controller;
+
+import java.security.Principal;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.cotato.itda.domain.chat.service.ChatMessageService;
+import com.cotato.itda.domain.websocket.dto.ChatSendMessageRequest;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * STOMP SEND 엔드포인트
+ * - destination: /app/chat/messages/send
+ *
+ * 임시 화면(roomId 없음)에서도 SEND가 가능해야 하므로
+ * roomId=null일 수 있고, 그때 opponentMemberId가 필요하다.
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageWsController {
+
+	private final ChatMessageService chatMessageService;
+
+	@MessageMapping("/chat/messages/send")
+	public void sendMessage(
+		Principal principal,
+		@Valid ChatSendMessageRequest req) {
+
+
+
+		log.info ("principal={}", principal);
+		Long senderMemberId = extractMemberId(principal);
+
+		log.info("사용자 '{}'가 채팅 메시지 전송 요청을 보냈습니다. 요청 내용: {}", senderMemberId, req);
+		chatMessageService.sendMessage(senderMemberId, req);
+
+		// 여기서 return을 굳이 하지 않는 이유:
+		// - 응답은 개인 큐 이벤트로 내려주는 구조
+		// - 실시간 타임라인은 /topic/chat/rooms/{roomId}로 발행
+	}
+
+	private Long extractMemberId(Principal principal) {
+
+		if (principal == null) {
+			throw new IllegalStateException("WS Principal이 null입니다. CONNECT에서 accessor.setUser(...)가 안 됐습니다.");
+		}
+
+		// WS에서는 principal이 대부분 Authentication(토큰)으로 들어옴
+		if (principal instanceof org.springframework.security.core.Authentication auth) {
+			Object p = auth.getPrincipal();
+
+			// auth.getPrincipal()이 JwtPrincipal인 경우
+			if (p instanceof com.cotato.itda.global.security.jwt.principal.JwtPrincipal jp) {
+				return jp.memberId();
+			}
+
+			// fallback: name이 숫자라면 (너는 getName을 memberId로 해놨으니 보통 여기로도 됨)
+			return Long.parseLong(auth.getName());
+		}
+
+		// Authentication이 아닌 경우는 거의 없지만, 최후 fallback
+		return Long.parseLong(principal.getName());
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatEventEnvelope.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatEventEnvelope.java
@@ -1,0 +1,19 @@
+package com.cotato.itda.domain.websocket.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+/**
+ * 개인 이벤트 채널로 보내는 이벤트 포맷
+ * - 프론트가 type으로 분기
+ * - data는 이벤트별 record로 내려줌
+ */
+@Builder
+public record ChatEventEnvelope<T> (
+	ChatEventType type,
+	Long roomId,
+	Long opponentMemberId, // DIRECT 일 때 상대 식별용
+	LocalDateTime eventAt,
+	T data
+) {}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatEventType.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatEventType.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.websocket.dto;
+
+public enum ChatEventType {
+	ROOM_CREATED, // 임시 화면에서 첫 SEND 후 roomId를 알려주기 위한 이벤트
+	ROOM_LIST_UPDATED, // 채팅 목록 갱신
+	READ_STATE_UPDATED // 읽음 갱신 이벤트
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatRoomMessageDto.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatRoomMessageDto.java
@@ -1,0 +1,34 @@
+package com.cotato.itda.domain.websocket.dto;
+
+import java.time.LocalDateTime;
+
+import com.cotato.itda.domain.chat.enums.AttachmentStatus;
+import com.cotato.itda.domain.chat.enums.AttachmentType;
+import com.cotato.itda.domain.chat.enums.MessageType;
+
+import lombok.Builder;
+
+/**
+ * 방 토픽(/topic/chat/room/{roomId})으로 보내는 실시간 타임라인 메시지
+ */
+@Builder
+public record ChatRoomMessageDto(
+	Long roomId,
+	Long messageId,
+	long messageSeq,
+	Long senderMemberId,
+	MessageType messageType,
+	String content,
+	LocalDateTime createdAt,
+	Attachment attachment
+) {
+	@Builder
+	public record Attachment(
+		AttachmentType attachmentType,
+		String objectKey,
+		String mimeType,
+		Integer sizeBytes,
+		AttachmentStatus status,
+		Integer durationMs
+	) {}
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatSendMessageRequest.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatSendMessageRequest.java
@@ -1,0 +1,19 @@
+package com.cotato.itda.domain.websocket.dto;
+
+import com.cotato.itda.domain.chat.enums.MessageType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.ToString;
+
+/**
+ * 임시 화면(roomId 없음)에서도 보내야 하므로 roomId는 nullable
+ * - clientMessageId: 클라이언트에서 생성한 메시지 ID (중복 방지 및 추적용)
+ */
+public record ChatSendMessageRequest(
+	@NotNull String clientMessageId,
+	Long roomId,
+	Long opponentMemberId, // roomId가 없을 때 필수
+	@NotNull MessageType messageType,
+	String content
+	){
+}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/RoomCreatedData.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/RoomCreatedData.java
@@ -1,0 +1,14 @@
+package com.cotato.itda.domain.websocket.dto;
+
+import lombok.Builder;
+
+/**
+ * 채팅방 생성 이벤트 데이터
+ * - ROOM_CREATED 이벤트의 data 필드에 해당
+ */
+@Builder
+public record RoomCreatedData(
+	Long firstMessageId,
+	long firstMessageSeq,
+	String lastMessagePreview
+){}

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/RoomListUpdatedData.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/RoomListUpdatedData.java
@@ -1,0 +1,21 @@
+package com.cotato.itda.domain.websocket.dto;
+
+import java.time.LocalDateTime;
+
+import com.cotato.itda.domain.chat.enums.LastMessageType;
+
+import lombok.Builder;
+
+/**
+ * 채팅방 목록 갱신 이벤트 데이터
+ * - ROOM_LIST_UPDATED 이벤트의 data 필드에 해당
+ */
+@Builder
+public record RoomListUpdatedData(
+	LocalDateTime lastMessageAt,
+	String lastMessagePreview,
+	LastMessageType lastMessageType,
+	Long lastMessageId,
+	Long lastMessageSeq
+) {
+}


### PR DESCRIPTION
연관 이슈

- close #59 

작업 내용 요약

- 채팅방 목록 커서 페이지네이션 조회 기능 추가

- 다이렉트 채팅방 존재 여부 조회 resolve API 추가

- 채팅 메시지 히스토리 슬라이스 조회 구조 추가

- 웹소켓 메시지 전송 플로우 및 이벤트 발행 모델 추가

주요 변경 사항

- 채팅 이벤트 모델

  - ChatEventType, ChatEventEnvelope

  - RoomCreatedData, RoomListUpdatedData

- 채팅방

  - ChatRoom, ChatRoomMember 엔티티 및 저장소 추가

  - ChatRoomQueryRepository로 목록 조회 최적화

  - ChatRoomService, ChatRoomController로 목록 조회 및 resolve API 제공

- 메시지

  - MessageRow, ChatMessageItemDto, ChatMessageSliceResponse로 조회 응답 정리

  - ChatMessageService와 리포지토리 계층 추가

  - ChatMessageWsController에서 전송 처리 진입점 추가

API 변경 사항

- GET /api/chat/rooms

  - cursorAt, cursorRoomId 기반 커서 페이지네이션

- GET /api/chat/rooms/direct/resolve

  - opponentMemberId로 다이렉트 방 존재 여부 조회

- 웹소켓 SEND 엔드포인트

   - 예시: /app/chat/messages/send


