### PR TITLE
feat 채팅방 나가기(LEFT) + 자연스러운 복귀(REJOIN) + 히스토리 노출 기준 적용

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
@@ -6,6 +6,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -112,5 +113,15 @@ public class ChatRoomController {
 		Long memberId = jwtPrincipal.memberId();
 		ChatMessageSliceResponse response = chatMessageService.getRoomMessages(memberId, roomId, limit, cursorSeq);
 		return ApiResponse.success(response);
+	}
+
+	@PostMapping("/left/{roomId}")
+	public ApiResponse<Void> leaveRoom(
+		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@PathVariable Long roomId
+	){
+		Long memberId = jwtPrincipal.memberId();
+		chatRoomService.leaveRoom(memberId, roomId);
+		return ApiResponse.success(null);
 	}
 }

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -129,13 +129,13 @@ public class ChatRoomMember extends BaseTimeEntity {
 		this.lastReadMessageId = readMesssageId;
 	}
 
-	public void setStatus(MemberRoomStatus status) {
-		this.status = status;
-		if (status == MemberRoomStatus.LEFT || status == MemberRoomStatus.KICKED) {
-			this.inactiveAt = LocalDateTime.now();
-		} else {
-			this.inactiveAt = null;
-		}
+	public void kick(){
+		this.status = MemberRoomStatus.KICKED;
+		this.inactiveAt = LocalDateTime.now();
+	}
+	public void leave() {
+		this.status = MemberRoomStatus.LEFT;
+		this.inactiveAt = LocalDateTime.now();
 	}
 
 	// 채팅 주제 변경

--- a/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
@@ -11,6 +11,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatErrorCode implements ErrorCode {
 
+	// 현재 상태가 ACTIVE가 아닙니다
+	CHAT_ROOM_MEMBER_STATUS_INVALID(
+		HttpStatus.BAD_REQUEST,
+		"현재 채팅 방 멤버의 상태가 유효하지 않습니다.",
+		"CHAT_ERROR_400_ROOM_MEMBER_STATUS_INVALID"
+	),
+
+
 	INVALID_REQUEST_BOTH_ROOMID_OPPONENTID_NULL(
 		HttpStatus.BAD_REQUEST,
 		"roomId와 opponentMemberId가 모두 null일 수 없습니다.",

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
@@ -27,6 +27,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 		@Param("status") MemberRoomStatus status
 	);
 
+	Optional<ChatRoomMember> findByRoomIdAndMemberId(Long roomId, Long memberId);
+
 	// 특정 roomId의 멤버 중 내가 아닌 멤버(상대)를 찾는 쿼리
 	// DIRECT에서만 사용
 	@Query("""

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
@@ -151,21 +151,18 @@ public class ChatRoomQueryRepository {
 		Long roomId = queryFactory
 			.select(cr.id)
 			.from(cr)
-			// 방 타입은 DIRECT만
 			.where(
 				cr.roomType.eq(RoomType.DIRECT),
 				cr.directMemberLowId.eq(low),
 				cr.directMemberHighId.eq(high)
 			)
-			// 내 membership
 			.join(m1).on(m1.room.eq(cr))
-			// 상대 membership (같은 room)
 			.join(m2).on(m2.room.eq(cr))
 			.where(
 				m1.member.id.eq(myMemberId),
-				m1.status.eq(MemberRoomStatus.ACTIVE),
+				m1.status.ne(MemberRoomStatus.KICKED),   //  ACTIVE 조건 제거, KICKED만 제외
 				m2.member.id.eq(opponentMemberId),
-				m2.status.eq(MemberRoomStatus.ACTIVE)
+				m2.status.ne(MemberRoomStatus.KICKED)    //  ACTIVE 조건 제거, KICKED만 제외
 			)
 			.fetchFirst();
 
@@ -181,6 +178,7 @@ public class ChatRoomQueryRepository {
 	public List<MessageRow> findRoomMessagesSlice(
 		Long roomId,
 		Long cursorSeq,
+		Long visibleFromSeq, //이 seq부터는 이 사람이 볼 수 있다 (재입장 이후)
 		int limitPlusOne
 	){
 		QChatMessage m = QChatMessage.chatMessage;
@@ -190,9 +188,20 @@ public class ChatRoomQueryRepository {
 		where.and(m.room.id.eq(roomId));
 		where.and(m.deletedAt.isNull());
 
+		// 재입장 이후만 보이게
+		if(visibleFromSeq != null){
+			// goe: greater or equal -> 크거나 같은 값
+			// message_seq >= visibleFromSeq
+			where.and(m.messageSeq.goe(visibleFromSeq));
+		}
 		// cursorSeq가 있으면 where 조건 추가
 		// 더 과거 메시지로
+		// 만약 cursorSeq가 visibleFromSeq 이하이면 빈 리스트 반환
+		// 왜냐하면 그 이후 메시지는 안 보이기 때문
 		if(cursorSeq!=null){
+			if (visibleFromSeq != null && cursorSeq <= visibleFromSeq) {
+				return List.of();
+			}
 			where.and(m.messageSeq.lt(cursorSeq));
 		}
 

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -91,9 +91,7 @@ public class ChatMessageService {
 		if (roomId == null) {
 			log.info("[방 resolve 시작] senderMemberId={}, opponentMemberId={}", senderMemberId, opponentMemberId);
 
-			// ⚠️ 버그 포인트: 지금 코드는 orElseGet 결과(기존방/신규방)를 구분하지 못해서 isRoomCreatedNow=true로 고정됨
-			// 아래 로그로 실제로 새로 만든 건지 확인 가능하게 분기 로그를 넣는다.
-			Long resolvedRoomId = chatRoomQueryRepository.resolveDirectRoomId(senderMemberId, opponentMemberId)
+		Long resolvedRoomId = chatRoomQueryRepository.resolveDirectRoomId(senderMemberId, opponentMemberId)
 				.orElse(null);
 
 			if (resolvedRoomId != null) {
@@ -129,16 +127,17 @@ public class ChatMessageService {
 			log.info("[방 결정 완료] 요청에 roomId 포함. roomId={}", roomId);
 		}
 
-		// ===== [3] 권한 체크 =====
-		log.info("[권한 체크] senderMemberId={} 가 roomId={} ACTIVE 멤버인지 확인", senderMemberId, roomId);
 
 		final Long lockedRoomId = roomId; // 람다 내에서 사용하기 위한 final 변수
+
 		ChatRoomMember myMembership = chatRoomMemberRepository
-			.findOneByRoomMemberStatus(roomId, senderMemberId, MemberRoomStatus.ACTIVE)
-			.orElseThrow(() -> {
-				log.warn("[권한 체크 실패] senderMemberId={} 는 roomId={} ACTIVE 멤버가 아님", senderMemberId, lockedRoomId);
-				return new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
-			});
+			.findByRoomIdAndMemberId(roomId, senderMemberId)
+			.orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
+
+		if (myMembership.getStatus() == MemberRoomStatus.KICKED) {
+			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
+		}
+
 
 		log.info("[권한 체크 성공] senderMemberId={} 는 roomId={} ACTIVE 멤버", senderMemberId, roomId);
 
@@ -155,6 +154,9 @@ public class ChatMessageService {
 		long lastSeq = (lastMessageSeq == null) ? 0L : lastMessageSeq;
 		long nextSeq = lastSeq + 1;
 
+		if (myMembership.getStatus() == MemberRoomStatus.LEFT) {
+			myMembership.rejoin(nextSeq);
+		}
 		log.info("[seq 발급] roomId={}, lastSeq={}, nextSeq={}", roomId, lastSeq, nextSeq);
 
 		ChatMessage message = ChatMessage.createChatMessage(
@@ -322,8 +324,19 @@ public class ChatMessageService {
 		int limitPlusOne = safeLimit + 1;
 
 		log.info("[히스토리 조회 파라미터] safeLimit={}, limitPlusOne={}, cursorSeq={}", safeLimit, limitPlusOne, cursorSeq);
+		ChatRoomMember myMembership = chatRoomMemberRepository
+			.findByRoomIdAndMemberId(roomId, memberId)
+			.orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
+		if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
+			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
+		}
+		// 내가 볼 수 있는 최초 메시지 시퀀스
+		// 재입장 이후 메시지부터 보임
+		// null이면 처음부터 다 보여줌
+		// null이면 한 번도 나가지 않은 것
+		Long visibleFromSeq = myMembership.getJoinSeq();
 
-		List<MessageRow> fetched = chatRoomQueryRepository.findRoomMessagesSlice(roomId, cursorSeq, limitPlusOne);
+		List<MessageRow> fetched = chatRoomQueryRepository.findRoomMessagesSlice(roomId, cursorSeq,visibleFromSeq, limitPlusOne);
 
 		boolean hasNext = fetched.size() > safeLimit;
 		List<MessageRow> page = hasNext ? fetched.subList(0, safeLimit) : fetched;

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -12,10 +12,17 @@ import com.cotato.itda.domain.chat.controller.dto.ChatRoomListItemDto;
 import com.cotato.itda.domain.chat.controller.dto.ChatRoomSliceResponse;
 import com.cotato.itda.domain.chat.controller.dto.DirectRoomResolveResponse;
 import com.cotato.itda.domain.chat.controller.dto.OpponentSummaryDto;
+import com.cotato.itda.domain.chat.entity.ChatRoom;
+import com.cotato.itda.domain.chat.entity.ChatRoomMember;
+import com.cotato.itda.domain.chat.enums.MemberRoomStatus;
 import com.cotato.itda.domain.chat.enums.RoomType;
+import com.cotato.itda.domain.chat.exception.code.ChatErrorCode;
+import com.cotato.itda.domain.chat.repository.ChatRoomMemberRepository;
 import com.cotato.itda.domain.chat.repository.ChatRoomQueryRepository;
+import com.cotato.itda.domain.chat.repository.ChatRoomRepository;
 import com.cotato.itda.domain.chat.repository.dto.MyRoomRow;
 import com.cotato.itda.domain.chat.repository.dto.OpponentRow;
+import com.cotato.itda.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ChatRoomService {
 	private final ChatRoomQueryRepository chatRoomQueryRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
 
 	public ChatRoomSliceResponse getMyRooms(
 		Long memberId,
@@ -198,5 +207,23 @@ public class ChatRoomService {
 				);
 				return new DirectRoomResolveResponse(false, null);
 			});
+	}
+
+	@Transactional
+	public void leaveRoom(Long memberId, Long roomId){
+		log.info("[채팅방 나가기 시작] memberId={}, roomId={}", memberId, roomId);
+
+		// 채팅방 존재하는지 조회
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+			.orElseThrow(()-> new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+		//현재 ACTIVE로 속해있는지 확인
+		ChatRoomMember chatRoomMember = chatRoomMemberRepository.findOneByRoomMemberStatus(
+			roomId, memberId, MemberRoomStatus.ACTIVE
+		).orElseThrow(()-> new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_STATUS_INVALID));
+
+		chatRoomMember.leave();
+
+
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 close #64 

배경

- 채팅방을 “나가기” 했을 때, 방 자체는 유지하되 사용자에게는 목록에서 숨겨지고(LEFT),
다시 메시지를 보내면 같은 방으로 자연스럽게 복귀(ACTIVE)하도록 UX를 맞춤.

- “복귀 후 과거 메시지 노출 정책”을 서버에서 강제하기 위해, 멤버십 단위 기준값(visibleFromSeq/joinSeq)을 적용.

변경 사항 요약

1. 채팅방 나가기(leave)

- ChatRoomMember.leave() 시 status = LEFT, inactiveAt = now 기록

2. 자연스러운 복귀(rejoin)

- sendMessage()에서 멤버십 상태가 LEFT인 경우

  - 방 row lock(findByIdForUpdate) 범위에서 nextSeq 계산

  - myMembership.rejoin(nextSeq)로 복귀 처리 (status ACTIVE + joinSeq/visibleFromSeq 갱신)

3. 기존 DIRECT 방 재사용 (중복 방 생성 방지)

- resolveDirectRoomId(my, opponent)에서 “둘 다 ACTIVE” 조건 제거

- 대신 KICKED는 제외하여 제재 정책 유지

4. 히스토리 조회 정책 강제

- 메시지 slice 조회 시 visibleFromSeq(joinSeq)를 하한으로 걸어,
재입장 정책에 맞게 과거 메시지 접근을 제한

동작 정책 (정의)

- LEFT: 채팅방 “숨김/아카이브” 의미

  - 방/메시지는 유지

  - 사용자가 다시 메시지를 보내면 같은 방에서 ACTIVE로 복귀 가능

- KICKED: 제재 의미

  - 재입장/메시지 전송 불가

  - resolve 단계에서도 제외

주요 구현 포인트

- rejoin 기준값은 room.lastMessageSeq + 1(= nextSeq)로 잡음

- 메시지 seq 발급과 동일한 락 범위에서 계산하여 동시성 일관성 보장

- “클라이언트 cursor 조작”으로 과거 메시지 접근이 가능하지 않도록,
조회 쿼리에서 visibleFromSeq 하한을 서버가 강제

