### PR TITLE
feat: ai모드&알림설정 토글 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/ChatRoomController.java
@@ -124,4 +124,26 @@ public class ChatRoomController {
 		chatRoomService.leaveRoom(memberId, roomId);
 		return ApiResponse.success(null);
 	}
+
+	@PostMapping("/toggle-ai/{roomId}")
+	public ApiResponse<Void> toggleAiMode(
+		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@PathVariable Long roomId,
+		@RequestParam boolean enabled
+	) {
+		Long memberId = jwtPrincipal.memberId();
+		chatRoomService.toggleAiMode(memberId, roomId,enabled);
+		return ApiResponse.success(null);
+	}
+
+	@PostMapping("/toggle-notification/{roomId}")
+	public ApiResponse<Void> toggleNotification(
+		@AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@PathVariable Long roomId,
+		@RequestParam boolean enabled
+	) {
+		Long memberId = jwtPrincipal.memberId();
+		chatRoomService.toggleNotification(memberId, roomId, enabled);
+		return ApiResponse.success(null);
+	}
 }

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -150,9 +150,18 @@ public class ChatRoomMember extends BaseTimeEntity {
 		this.chatFrequency = frequency;
 	}
 
-	public void leave(MemberRoomStatus reason, LocalDateTime when) {
-		this.status = reason;
-		this.inactiveAt = when;
+	public void setAiModeEnabled(boolean enabled){
+		if(this.status  != MemberRoomStatus.ACTIVE){
+			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
+		}
+		this.aiModeEnabled = enabled;
+	}
+
+	public void setNotificationEnabled(boolean enabled) {
+		if (this.status != MemberRoomStatus.ACTIVE) {
+			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_STATUS_INVALID);
+		}
+		this.notificationEnabled = enabled;
 	}
 
 	public void rejoin(long newJoinSeq) {

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -226,4 +226,30 @@ public class ChatRoomService {
 
 
 	}
+
+	// AI 모드 토글
+	@Transactional
+	public void toggleAiMode(Long memberId, Long roomId, boolean enabled) {
+		log.info("[AI 모드 토글 시작] memberId={}, roomId={}, enabled={}", memberId, roomId, enabled);
+
+		//현재 ACTIVE로 속해있는지 확인
+		ChatRoomMember chatRoomMember = chatRoomMemberRepository.findOneByRoomMemberStatus(
+			roomId, memberId, MemberRoomStatus.ACTIVE
+		).orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_STATUS_INVALID));
+
+		chatRoomMember.setAiModeEnabled(enabled);
+	}
+
+	// 알림 설정 토글
+	@Transactional
+	public void toggleNotification(Long memberId, Long roomId, boolean enabled) {
+		log.info("[알림 설정 토글 시작] memberId={}, roomId={}, enabled={}", memberId, roomId, enabled);
+
+		//현재 ACTIVE로 속해있는지 확인
+		ChatRoomMember chatRoomMember = chatRoomMemberRepository.findOneByRoomMemberStatus(
+			roomId, memberId, MemberRoomStatus.ACTIVE
+		).orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_STATUS_INVALID));
+		chatRoomMember.setNotificationEnabled(enabled);
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
close #66 

변경 배경

- 채팅방 단위로 사용자 개인 설정(AI 모드, 알림 여부)을 ON/OFF 할 수 있도록 기능 추가

구현 내용

- Controller

  - POST /toggle-ai/{roomId}?enabled={true|false}

  - POST /toggle-notification/{roomId}?enabled={true|false}

  - 인증된 사용자(memberId) 기준으로 해당 room 설정 토글

- Service

  - ACTIVE 멤버십만 토글 가능하도록 검증

  - toggleAiMode, toggleNotification 유스케이스 구현

- Entity (ChatRoomMember)

  - setAiModeEnabled(enabled) / setNotificationEnabled(enabled) 도메인 메서드 추가

  - ACTIVE 상태 검증 후 값 변경

API 스펙

- AI 모드 토글

  - Method: POST

  - Path: /api/chat/rooms/toggle-ai/{roomId}

  - Query: enabled (boolean)

  - Response: 200 OK (ApiResponse<Void>)

- 알림 토글

  - Method: POST

  - Path: /api/chat/rooms/toggle-notification/{roomId}

  - Query: enabled (boolean)

  - Response: 200 OK (ApiResponse<Void>)

정책/권한

- ChatRoomMember.status == ACTIVE인 경우에만 토글 가능

- ACTIVE가 아니면 예외 반환
