### PR TITLE
feat: 대화 주제별 템플릿 조회 API 추가

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chattopic/controller/ChatTopicController.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/controller/ChatTopicController.java
@@ -1,11 +1,16 @@
 package com.cotato.itda.domain.chattopic.controller;
 
 import com.cotato.itda.domain.chattopic.dto.res.ChatTopicResDTO;
+import com.cotato.itda.domain.chattopic.dto.res.ChatTopicTemplateResponse;
 import com.cotato.itda.domain.chattopic.service.query.ChatTopicQueryService;
+import com.cotato.itda.domain.chattopic.service.query.ChatTopicTemplateService;
 import com.cotato.itda.global.common.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,10 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatTopicController implements ChatTopicControllerDocs {
 
     private final ChatTopicQueryService chatTopicQueryService;
-
+    private final ChatTopicTemplateService chatTopicTemplateService;
     @GetMapping
     @Override
-    public ApiResponse<ChatTopicResDTO.ChatTopicListDTO> getChatTopics() {
+    public ApiResponse<ChatTopicResDTO.ChatTopicListDTO> getChatTopics()
+     {
         return ApiResponse.success(chatTopicQueryService.getChatTopics());
+    }
+
+    
+    @GetMapping("/{topicCode}/templates")
+    @Operation(summary="채팅 주제에 해당하는 템플릿 조회 API", description="채팅 주제에 해당하는 템플릿을 조회합니다.")
+    public ApiResponse<ChatTopicTemplateResponse> getChatTopicTemplates(
+        @PathVariable String topicCode
+    ) {
+        return ApiResponse.success(
+            chatTopicTemplateService.getChatTopicTemplates(topicCode)
+        );
     }
 }

--- a/src/main/java/com/cotato/itda/domain/chattopic/dto/res/ChatTopicTemplateResponse.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/dto/res/ChatTopicTemplateResponse.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.chattopic.dto.res;
+
+import java.util.List;
+
+public record ChatTopicTemplateResponse (
+	List<String> templates
+){
+}

--- a/src/main/java/com/cotato/itda/domain/chattopic/entity/ChatTopic.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/entity/ChatTopic.java
@@ -4,6 +4,7 @@ import com.cotato.itda.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.*;
 
 @Entity
@@ -11,7 +12,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(name = "chat_topic")
+@Table(name = "chat_topic",
+    uniqueConstraints= {
+        @UniqueConstraint(name = "uk_chat_topic_code", columnNames = {"code"})
+    }
+)
 public class ChatTopic extends BaseEntity {
 
     @Column(name = "name", nullable = false)

--- a/src/main/java/com/cotato/itda/domain/chattopic/entity/ChatTopicTemplate.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/entity/ChatTopicTemplate.java
@@ -1,6 +1,5 @@
-package com.cotato.itda.domain.chat.entity;
+package com.cotato.itda.domain.chattopic.entity;
 
-import com.cotato.itda.domain.chattopic.entity.ChatTopic;
 import com.cotato.itda.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/cotato/itda/domain/chattopic/exception/code/ChatTopicErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/exception/code/ChatTopicErrorCode.java
@@ -9,6 +9,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ChatTopicErrorCode implements ErrorCode {
 
+    CHAT_TOPIC_TEMPLATE_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "CHAT_TOPIC_ERROR_404_CHAT_TOPIC_TEMPLATE_NOT_FOUND",
+            "대화 주제 템플릿을 찾을 수 없습니다."
+    ),
+    CHAT_TOPIC_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "CHAT_TOPIC_ERROR_404_CHAT_TOPIC_NOT_FOUND",
+            "대화 주제를 찾을 수 없습니다."
+    ),
     NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "CHAT_TOPIC_ERROR_404_NOT_FOUND",

--- a/src/main/java/com/cotato/itda/domain/chattopic/repository/ChatTopicRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/repository/ChatTopicRepository.java
@@ -4,9 +4,12 @@ import com.cotato.itda.domain.chattopic.entity.ChatTopic;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatTopicRepository extends JpaRepository<ChatTopic, Long> {
     List<ChatTopic> findAllByCodeIn(List<String> codes);
 
     List<ChatTopic> findAllByIsActiveTrue();
+
+    Optional<ChatTopic> findByCodeAndIsActiveTrue(String code);
 }

--- a/src/main/java/com/cotato/itda/domain/chattopic/repository/ChatTopicTemplateRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/repository/ChatTopicTemplateRepository.java
@@ -1,0 +1,11 @@
+package com.cotato.itda.domain.chattopic.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cotato.itda.domain.chattopic.entity.ChatTopicTemplate;
+
+public interface ChatTopicTemplateRepository extends JpaRepository<ChatTopicTemplate,Long> {
+	List<ChatTopicTemplate> findAllByTopic_IdAndActiveTrueOrderByPriorityAsc(Long chatTopicId);
+}

--- a/src/main/java/com/cotato/itda/domain/chattopic/service/query/ChatTopicQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/service/query/ChatTopicQueryServiceImpl.java
@@ -23,4 +23,6 @@ public class ChatTopicQueryServiceImpl implements ChatTopicQueryService {
 
         return ChatTopicConverter.toChatTopicListDTO(chatTopics);
     }
+
+
 }

--- a/src/main/java/com/cotato/itda/domain/chattopic/service/query/ChatTopicTemplateService.java
+++ b/src/main/java/com/cotato/itda/domain/chattopic/service/query/ChatTopicTemplateService.java
@@ -1,0 +1,40 @@
+package com.cotato.itda.domain.chattopic.service.query;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.chattopic.dto.res.ChatTopicTemplateResponse;
+import com.cotato.itda.domain.chattopic.entity.ChatTopic;
+import com.cotato.itda.domain.chattopic.entity.ChatTopicTemplate;
+import com.cotato.itda.domain.chattopic.exception.code.ChatTopicErrorCode;
+import com.cotato.itda.domain.chattopic.repository.ChatTopicRepository;
+import com.cotato.itda.domain.chattopic.repository.ChatTopicTemplateRepository;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatTopicTemplateService {
+
+	private final ChatTopicRepository chatTopicRepository;
+	private final ChatTopicTemplateRepository chatTopicTemplateRepository;
+
+	public ChatTopicTemplateResponse getChatTopicTemplates(String topicCode) {
+		ChatTopic chatTopic = chatTopicRepository.findByCodeAndIsActiveTrue(topicCode)
+			.orElseThrow(() -> new BusinessException(ChatTopicErrorCode.CHAT_TOPIC_NOT_FOUND));
+
+		Long topicId = chatTopic.getId();
+
+		List<ChatTopicTemplate> items = chatTopicTemplateRepository.findAllByTopic_IdAndActiveTrueOrderByPriorityAsc(
+			topicId);
+
+		List<String> templateContents = items.stream()
+			.map(template -> template.getTemplateText())
+			.toList();
+		return new ChatTopicTemplateResponse(templateContents);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
close #68 

구현 내용
- API 추가
  - 주제별 템플릿 조회: GET /api/chat-topics/{topicCode}/templates
- ChatTopicTemplate
  - 활성 템플릿만 조회 + 우선순위 정렬API 스펙

- 대화 주제 목록 조회

  - Method: GET

  - Path: /api/chat-topics

  - Response: ApiResponse<ChatTopicListDTO>

- 주제별 템플릿 조회

  - Method: GET

  - Path: /api/chat-topics/{topicCode}/templates

  - PathVariable: topicCode (예: WEATHER)

  - Response: ApiResponse<ChatTopicTemplateResponse>## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
