### PR TITLE
feat 비밀번호 재설정 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,18 +38,25 @@ dependencyManagement {
  * Querydsl Q 클래스 생성 위치 (빌드 디렉토리)
  * - 생성물은 빌드 결과물이므로 Git에 커밋하지 않는 게 정석
  */
-def querydslDir = "$buildDir/generated/querydsl"
+def querydslDir = layout.buildDirectory.dir("generated/querydsl")
+def querydslTestDir = layout.buildDirectory.dir("generated/querydslTest")
 
-sourceSets {
-	main {
-		java {
-			srcDirs += querydslDir
-		}
-	}
+tasks.named('compileJava', JavaCompile) {
+	options.generatedSourceOutputDirectory.set(querydslDir)
 }
 
-tasks.withType(JavaCompile).configureEach {
-	options.generatedSourceOutputDirectory.set(file(querydslDir))
+tasks.named('compileTestJava', JavaCompile) {
+	options.generatedSourceOutputDirectory.set(querydslTestDir)
+}
+
+// IDE에서 소스처럼 보이게 하고 싶으면(선택)
+sourceSets {
+	main {
+		java.srcDir(querydslDir)
+	}
+	test {
+		java.srcDir(querydslTestDir)
+	}
 }
 
 tasks.named("clean") {

--- a/src/main/java/com/cotato/itda/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/cotato/itda/domain/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.cotato.itda.domain.member.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.cotato.itda.domain.member.entity.Member;
 
@@ -10,4 +12,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByPhoneNumber(String phoneNumber);
 
 	Boolean existsByPhoneNumber(String phoneNumber);
+
+	// 핸드폰 번호와 이름으로 조회
+	Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+        update Member m
+           set m.passwordHash = :encodedPassword
+         where m.phoneNumber = :phoneNumber
+    """)
+	void updatePasswordByPhoneNumber(String encodedPassword, String phoneNumber);
+
 }

--- a/src/main/java/com/cotato/itda/domain/passwordreset/config/PasswordResetProperties.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/config/PasswordResetProperties.java
@@ -1,0 +1,15 @@
+package com.cotato.itda.domain.passwordreset.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix="password-reset")
+public class PasswordResetProperties {
+	private long draftTtlMinutes;
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/controller/PasswordResetController.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/controller/PasswordResetController.java
@@ -1,0 +1,159 @@
+package com.cotato.itda.domain.passwordreset.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cotato.itda.domain.passwordreset.dto.SendOtpRequest;
+import com.cotato.itda.domain.passwordreset.dto.response.PasswordResetCreateDraftResponse;
+import com.cotato.itda.domain.passwordreset.service.PasswordResetDraftService;
+import com.cotato.itda.domain.passwordreset.service.PasswordResetOtpVerifyService;
+import com.cotato.itda.domain.passwordreset.service.PasswordResetPasswordService;
+import com.cotato.itda.domain.passwordreset.service.PasswordResetSmsService;
+import com.cotato.itda.domain.signup.dto.request.SendOtpSmsRequest;
+import com.cotato.itda.domain.signup.dto.request.SubmitPasswordRequest;
+import com.cotato.itda.domain.signup.dto.request.VerifyOtpRequest;
+import com.cotato.itda.domain.signup.dto.response.SendOtpSmsResponse;
+import com.cotato.itda.domain.signup.dto.response.SubmitPasswordResponse;
+import com.cotato.itda.domain.signup.dto.response.VerifyOtpResponse;
+import com.cotato.itda.global.common.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(
+	name = "Password Reset",
+	description = "비밀번호 재설정 단계별 API"
+)
+@RequestMapping("/api/password-reset")
+@RestController
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+	/**
+	 * Password Reset 흐름에서 서버가 발급한 임시 draftKey를 담아 주고받는 헤더 이름.
+	 * - 클라이언트는 이후 요청마다 이 헤더를 보내야 한다.
+	 * - 예: Password-Reset-Draft-Key: 550e8400-e29b-41d4-a716-446655440000
+	 */
+	private static final String HEADER_DRAFT_KEY = "Password-Reset-Draft-Key";
+	private final PasswordResetDraftService passwordResetDraftService;
+	private final PasswordResetSmsService passwordResetSmsService;
+	private final PasswordResetOtpVerifyService passwordResetOtpVerifyService;
+	private final PasswordResetPasswordService passwordResetPasswordService;
+	@Operation(
+		summary = "STEP1) Password Reset Draft 생성",
+		description = "비밀번호 재설정을 위한 Draft를 생성합니다. 생성된 Draft Key는 이후 요청에 사용됩니다."
+	)
+	@PostMapping("/drafts")
+	public ResponseEntity<ApiResponse<PasswordResetCreateDraftResponse>> createPasswordResetDraft(){
+		PasswordResetDraftService.DraftCreationResult result= passwordResetDraftService.createDraft();
+		return ResponseEntity
+			.ok()
+			.header(HEADER_DRAFT_KEY, result.draftKey())
+			.body(ApiResponse.success(result.response()));
+	}
+
+	/**
+	 * Step2) 인증번호(SMS) 발송
+	 * <p>
+	 * ✅ API
+	 * - POST /api/signup/sms/send
+	 * - Header: Signup-Draft-Key
+	 * - Body: { "phoneNumber": "01012345678", name="김기민" }
+	 */
+	@Operation(
+		summary = "Step2) 인증번호 SMS 발송",
+		description = "입력된 전화번호로 OTP 인증번호를 SMS로 발송한다. DraftKey가 유효해야 한다.",
+		security = {}
+	)
+	@PostMapping("/sms/send")
+	public ApiResponse<SendOtpSmsResponse> sendOptSms(
+		@Parameter(
+			name = HEADER_DRAFT_KEY,
+			in = ParameterIn.HEADER,
+			required = true,
+			description = "Step1에서 발급받은 draftKey",
+			example = "550e8400-e29b-41d4-a716-446655440000"
+		)
+		@RequestHeader(HEADER_DRAFT_KEY) String draftKey,
+
+		@RequestBody @Valid SendOtpRequest request
+	) {
+		log.info("SignupController.sendOptSms: draftKey={}, phoneNumber={}", draftKey, request.phoneNumber());
+		SendOtpSmsResponse response = passwordResetSmsService.sendOtpSms(draftKey, request);
+		return ApiResponse.success(response);
+	}
+
+	/**
+	 * Step3) 인증번호(OTP) 검증
+	 * 	 * 예시
+	 * 	 * - Request Header: Signup-Draft-Key: 550e8400-e29b-41d4-a716-446655440000
+	 * 	 * - Request Body: { "otpCode": "1234" }
+	 */
+	@Operation(
+		summary = "Step3) OTP 검증",
+		description = "DraftKey 기반 회원가입 흐름에서 OTP를 검증한다. 결과는 nextAction으로 분기한다.",
+		security = {}
+	)
+	@PostMapping("/otp/verify")
+	public ApiResponse<VerifyOtpResponse> verifyOtp(
+		@Parameter(
+			name = HEADER_DRAFT_KEY,
+			in = ParameterIn.HEADER,
+			required = true,
+			description = "Step1에서 발급받은 DraftKey",
+			example = "550e8400-e29b-41d4-a716-446655440000"
+		)
+		@RequestHeader(HEADER_DRAFT_KEY) String draftKey,
+		@RequestBody @Valid VerifyOtpRequest request
+	) {
+		return ApiResponse.success(passwordResetOtpVerifyService.verify(draftKey, request));
+	}
+
+	/**
+	 * STEP4) 새 비밀번호 설정
+	 * <p>
+	 * - Controller는 HTTP 바인딩만 담당한다.
+	 * - Draft 조회/검증/상태전이/저장은 Service에서 한다.
+	 * <p>
+	 * 예시
+	 * - Request Header: Password-Reset-Draft-Key: 550e8400-e29b-41d4-a716-446655440000
+	 * - Request Body: { "newPassword": "NewP@ssw0rd!" }
+	 */
+	@Operation(
+		summary = "Step4) 비밀번호 재설정",
+		description = """
+			DraftKey 흐름에서 비밀번호를 재설정한다.
+			
+			- Header: Signup-Draft-Key (Step1에서 발급)
+			- Body: password / passwordConfirm(또는 confirmPassword) 등 비밀번호 입력값
+			- 성공 시: 비밀번호 변경 + 로그인 페이지로 이동 유도
+			""",
+		security = {}
+	)
+	@PostMapping("/password")
+	public ApiResponse<Void> submitPassword(
+		@Parameter(
+			name = HEADER_DRAFT_KEY,
+			in = ParameterIn.HEADER,
+			required = true,
+			description = "Step1에서 발급받은 DraftKey. 이후 모든 단계 요청에 포함한다.",
+			example = "550e8400-e29b-41d4-a716-446655440000"
+		)
+		@RequestHeader(HEADER_DRAFT_KEY) String draftKey,
+
+		@RequestBody @Valid SubmitPasswordRequest request
+	) {
+		return ApiResponse.success(passwordResetPasswordService.resetPassword(draftKey, request));
+	}
+}
+

--- a/src/main/java/com/cotato/itda/domain/passwordreset/dto/PasswordResetDraftRedisValue.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/dto/PasswordResetDraftRedisValue.java
@@ -1,0 +1,261 @@
+package com.cotato.itda.domain.passwordreset.dto;
+
+import java.time.OffsetDateTime;
+
+import com.cotato.itda.domain.signup.dto.SignupDraftRedisValue;
+import com.cotato.itda.global.error.constant.PasswordResetErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import lombok.Builder;
+
+@Builder
+public record PasswordResetDraftRedisValue(
+	String draftKey,
+	DraftMeta meta,
+	PasswordResetStep step,
+
+	Long memberId, // OTP 검증 성공 후 세팅
+	OtpState otpState
+) {
+
+	@Builder
+	public record OtpState(
+		String phone,                  // 사용자가 입력한 원본(표준화된 형태 권장: 01012345678)
+
+		boolean canSendSms,            // Step2 직후 true, Step3 직후 false
+		int smsSendCount,              // Step3 호출 횟수
+		int remainingOtpAttempts,      // “현재 발급된 OTP”에 대한 남은 시도 횟수 (예: 3)
+
+		int remainingResendCount,     // 남은 재전송 횟수 (예: 3)
+		//레디스에 저장할때는 OffsetDateTime 형태로 저장
+		OffsetDateTime resendAvailableAt, // 재전송 가능 시각
+		OffsetDateTime otpExpiresAt,       // OTP 만료 시각
+		String otpCodeHash,			// OTP 코드 해시값 (STEP3에서 채워짐 -> STEP4에서 검증)
+
+		boolean phoneVerified,         // Step4 성공 시 true
+		OffsetDateTime verifiedAt    // Step4 성공 시각
+	) {
+	}
+
+	/**
+	 * createdAt/updatedAt 등의 메타 정보
+	 */
+	public record DraftMeta(
+		OffsetDateTime createdAt,
+		OffsetDateTime updatedAt
+	) {
+		public DraftMeta withUpdatedAt() {
+			return new DraftMeta(this.createdAt, OffsetDateTime.now());
+		}
+	}
+
+	// Step 1: Draft 최초 생성(OTP_REQUIRED)
+	public static PasswordResetDraftRedisValue newDraft(String draftKey) {
+		OffsetDateTime now = OffsetDateTime.now();
+
+		OtpState otpInit = OtpState.builder()
+			.phone(null)                  // phone (step3에서 채워짐)
+			.canSendSms(true)             // canSendSms
+			.smsSendCount(0)              // smsSendCount , 아직 전송 안함
+			.remainingOtpAttempts(3)      // remainingOtpAttempts , 초기값 3회
+			.remainingResendCount(3)      // remainingResendCount , 초기값 3회
+			.resendAvailableAt(null)      // resendAvailableAt (Step2에서 채워짐)(역할: 재전송 가능 시각)
+			.otpExpiresAt(null)           // otpExpiresAt (Step2에서 채워짐)(역할: OTP 만료 시각)
+			.otpCodeHash(null)            // otpCodeHash (STEP2에서 채워짐)
+			.phoneVerified(false)         // phoneVerified
+			.verifiedAt(null)             // verifiedAt (Step3에서 채워짐)(역할: 인증 성공 시각)
+			.build();
+
+		return PasswordResetDraftRedisValue.builder()
+			.draftKey(draftKey)
+			.meta(new DraftMeta(now, now))
+			.step(PasswordResetStep.OTP_REQUIRED)
+			.memberId(null)
+			.otpState(otpInit)
+			.build();
+	}
+
+	// Step 2: SMS 발송 성공 후 OTP 상태 갱신
+	// - otpState 값들 세팅
+	// meberId 도 세팅 (서비스 로직에서 phone, 이름 입력받은걸로 멤버 조회&검증 후 아이디 세팅)
+	public PasswordResetDraftRedisValue onSmsSent(
+		String phone,
+		Long memberId,
+		OffsetDateTime resendAvailableAt,
+		OffsetDateTime otpExpiresAt,
+		String otpCodeHash
+	) {
+		if (this.step != PasswordResetStep.OTP_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+		if (this.otpState == null) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_STATE_NOT_FOUND);
+		}
+		if (this.otpState.remainingResendCount() <= 0) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_RESEND_LIMIT_EXCEEDED);
+		}
+		OtpState nextOtp = OtpState.builder()
+			.phone(phone)
+			.canSendSms(false) // SMS 발송 직후에는 재전송 불가
+			.smsSendCount(this.otpState.smsSendCount() + 1)
+			.remainingOtpAttempts(3) // OTP 발송 시도 시 남은 시도 횟수 초기화
+			.remainingResendCount(this.otpState.remainingResendCount() - 1) // 재전송 가능 횟수 차감
+			.resendAvailableAt(resendAvailableAt)
+			.otpExpiresAt(otpExpiresAt)
+			.otpCodeHash(otpCodeHash)
+			.phoneVerified(false)
+			.verifiedAt(null)
+			.build();
+
+		return PasswordResetDraftRedisValue.builder()
+			.draftKey(this.draftKey)
+			.meta(this.meta.withUpdatedAt())
+			.step(this.step) //여전히 OTP_REQUIRED
+			.memberId(memberId)
+			.otpState(nextOtp)
+			.build();
+	}
+
+	/**
+	 * STEP 3 성공: OTP 검증 성공 후 멤버 ID 세팅
+	 * - otpState.phoneVerified = true
+	 * - otpState.verifiedAt 세팅
+	 * - step = PROFILE_REQUIRED
+	 */
+	public PasswordResetDraftRedisValue onOtpVerified() {
+		if (this.step != PasswordResetStep.OTP_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+		if (this.otpState == null) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_STATE_NOT_FOUND);
+		}
+		if(this.memberId==null){
+			throw new BusinessException(PasswordResetErrorCode.MEMBER_ID_NOT_SET);
+		}
+		OtpState nextOtp = OtpState.builder()
+			.phone(this.otpState.phone())
+			.canSendSms(this.otpState.canSendSms())
+			.smsSendCount(this.otpState.smsSendCount())
+			.remainingOtpAttempts(this.otpState.remainingOtpAttempts())
+			.remainingResendCount(this.otpState.remainingResendCount())
+			.resendAvailableAt(this.otpState.resendAvailableAt())
+			.otpExpiresAt(this.otpState.otpExpiresAt())
+			.otpCodeHash(this.otpState.otpCodeHash())
+			.phoneVerified(true)
+			.verifiedAt(OffsetDateTime.now())
+			.build();
+
+		return PasswordResetDraftRedisValue.builder()
+			.draftKey(this.draftKey)
+			.meta(this.meta.withUpdatedAt())
+			.step(PasswordResetStep.PASSWORD_REQUIRED) //다음 스텝으로
+			.memberId(this.memberId)
+			.otpState(nextOtp)
+			.build();
+	}
+
+	/**
+	 * STEP 3 실패: OTP 검증 실패 시 남은 시도 횟수 차감
+	 * - otpState.remainingOtpAttempts 차감
+	 */
+	public PasswordResetDraftRedisValue onOtpVerifyFailed() {
+		if (this.step != PasswordResetStep.OTP_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+		if (this.otpState == null) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_STATE_NOT_FOUND);
+		}
+		int nextRemainingAttempts = Math.max(0, this.otpState.remainingOtpAttempts() - 1);
+		OtpState nextOtp;
+		if (nextRemainingAttempts == 0) {
+			//남은 시도 횟수 0회면 재전송 가능하도록 변경
+			nextOtp = OtpState.builder()
+				.phone(this.otpState.phone())
+				.canSendSms(true) // 재전송 가능하도록 변경
+				.smsSendCount(this.otpState.smsSendCount())
+				.remainingOtpAttempts(nextRemainingAttempts)
+				.remainingResendCount(this.otpState.remainingResendCount())
+				.resendAvailableAt(OffsetDateTime.now()) // 재전송 가능 시각 즉시
+				.otpExpiresAt(OffsetDateTime.now()) //만료 시간도 현재 시각으로 변경
+				.otpCodeHash(this.otpState.otpCodeHash())
+				.phoneVerified(false)
+				.verifiedAt(null)
+				.build();
+		} else { //아직 남은 시도 횟수 있음
+			nextOtp = OtpState.builder()
+				.phone(this.otpState.phone())
+				.canSendSms(this.otpState.canSendSms())
+				.smsSendCount(this.otpState.smsSendCount())
+				.remainingOtpAttempts(nextRemainingAttempts) //감소된 값
+				.remainingResendCount(this.otpState.remainingResendCount())
+				.resendAvailableAt(this.otpState.resendAvailableAt())
+				.otpExpiresAt(this.otpState.otpExpiresAt())
+				.otpCodeHash(this.otpState.otpCodeHash())
+				.phoneVerified(false)
+				.verifiedAt(null)
+				.build();
+		}
+
+		return PasswordResetDraftRedisValue.builder()
+			.draftKey(this.draftKey)
+			.meta(this.meta.withUpdatedAt())
+			.step(this.step) //여전히 OTP_REQUIRED
+			.memberId(this.memberId)
+			.otpState(nextOtp)
+			.build();
+	}
+
+	// Step 4: 비밀번호 재설정 완료 후 DB 커밋 완료 후 COMPLETED 로 전이
+	public PasswordResetDraftRedisValue onPasswordResetCompleted() {
+		if (this.step != PasswordResetStep.PASSWORD_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+
+		return PasswordResetDraftRedisValue.builder()
+			.draftKey(this.draftKey)
+			.meta(this.meta.withUpdatedAt())
+			.step(PasswordResetStep.PASSWORD_RESET_COMPLETED) //완료 상태로
+			.memberId(this.memberId)
+			.otpState(this.otpState)
+			.build();
+	}
+	// 재전송 가능 상태로 변경 가능한지 검사 후, 가능하면 변경해주는 유틸 메서드
+	public static PasswordResetDraftRedisValue enableResendNowIfPossible(PasswordResetDraftRedisValue draft) {
+		// 남은 재전송 횟수 없으면 불가능
+		if (draft.otpState().remainingResendCount() <= 0) return draft;
+
+		// 이미 canSendSms=true면 그대로
+		if (draft.otpState().canSendSms()) return draft;
+
+		// canSendSms=false인데, now >= resendAvailableAt이면 true로 켤 수 있다.
+		OffsetDateTime now = OffsetDateTime.now();
+		OffsetDateTime resendAt = draft.otpState().resendAvailableAt();
+
+		if (resendAt == null || !now.isBefore(resendAt)) {
+			// OtpState만 살짝 갱신한 새 Draft를 만들어준다.
+			// (record라서 불변이므로 builder로 재구성)
+			OtpState nextOtp = OtpState.builder()
+				.phone(draft.otpState().phone())
+				.canSendSms(true)
+				.smsSendCount(draft.otpState().smsSendCount())
+				.remainingOtpAttempts(draft.otpState().remainingOtpAttempts())
+				.remainingResendCount(draft.otpState().remainingResendCount())
+				.resendAvailableAt(now)
+				.otpExpiresAt(draft.otpState().otpExpiresAt())
+				.otpCodeHash(draft.otpState().otpCodeHash())
+				.phoneVerified(draft.otpState().phoneVerified())
+				.verifiedAt(draft.otpState().verifiedAt())
+				.build();
+
+			return PasswordResetDraftRedisValue.builder()
+				.draftKey(draft.draftKey())
+				.step(draft.step())
+				.meta(draft.meta().withUpdatedAt())
+				.memberId(draft.memberId())
+				.otpState(nextOtp)
+				.build();
+		}
+
+		return draft;
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/dto/PasswordResetStep.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/dto/PasswordResetStep.java
@@ -1,0 +1,7 @@
+package com.cotato.itda.domain.passwordreset.dto;
+
+public enum PasswordResetStep {
+	OTP_REQUIRED, // OTP 발송 필요 상태
+	PASSWORD_REQUIRED, // 비밀번호 제출 필요 상태
+	PASSWORD_RESET_COMPLETED // 비밀번호 재설정 완료 상태
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/dto/SendOtpRequest.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/dto/SendOtpRequest.java
@@ -1,0 +1,13 @@
+package com.cotato.itda.domain.passwordreset.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * STEP 3 요청 DTO
+ * - phoneNumber: OTP 발송할 핸드폰 번호
+ */
+public record SendOtpRequest(
+	@NotBlank(message="핸드폰 번호 입력은 필수입니다") String phoneNumber,
+	@NotBlank(message="이름 입력은 필수입니다") String name
+) {
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/dto/response/PasswordResetCreateDraftResponse.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/dto/response/PasswordResetCreateDraftResponse.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.passwordreset.dto.response;
+
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetStep;
+
+public record PasswordResetCreateDraftResponse (
+	PasswordResetStep step
+){
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/repository/PasswordResetDraftRedisRepository.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/repository/PasswordResetDraftRedisRepository.java
@@ -1,0 +1,108 @@
+package com.cotato.itda.domain.passwordreset.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetDraftRedisValue;
+import com.cotato.itda.global.error.constant.RedisErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
+public class PasswordResetDraftRedisRepository {
+
+	private static final String KEY_PREFIX = "password-reset:draft:";
+
+	private final StringRedisTemplate redis;
+
+	private final ObjectMapper redisObjectMapper;
+
+	/**
+	 * Draft 데이터를 Redis에 저장
+	 * ttl: 만료 시간
+	 * 실제 메서드 호출 예시
+	 * passwordResetDraftRedisRepository.save(value, Duration.ofMinutes(10));
+	 */
+	public void save(PasswordResetDraftRedisValue value, Duration ttl){
+		if(ttl==null|| ttl.isZero() || ttl.isNegative()){
+			throw new BusinessException(RedisErrorCode.INVALID_TTL);
+		}
+		String redisKey = KEY_PREFIX + value.draftKey();
+
+		// 객체 -> JSON 변환
+		String json = toJson(value);
+
+		// Redis에 데이터 저장 및 만료 시간 설정
+		// 동작 원리:
+		// 1. redisKey와 json 문자열을 Redis에 저장
+		// 2. ttl이 지나면 해당 키-값 쌍이 자동으로 삭제됨
+		// 이 시점에 실제 Redis 서버에 데이터가 저장됨
+		redis.opsForValue().set(redisKey, json, ttl);
+
+		// 저장 확인
+		Boolean exists = redis.hasKey(redisKey);
+
+		Long seconds = redis.getExpire(redisKey);
+		log.info("Redis Key Exists: {}, TTL(seconds): {}", exists, seconds);
+	}
+
+	public Optional<PasswordResetDraftRedisValue> findByDraftKey(String draftKey){
+		String redisKey = KEY_PREFIX + draftKey;
+		String json;
+
+		json = redis.opsForValue().get(redisKey);
+		Boolean exists = redis.hasKey(redisKey);
+		Long seconds = redis.getExpire(redisKey);
+		log.info("Redis Key Exists: {}, TTL(seconds): {}", exists, seconds);
+
+		if(json==null){
+			return Optional.empty();
+		}
+		try{
+			// JSON 문자열을 PasswordResetDraftRedisValue 객체로 역직렬화
+			return Optional.of(redisObjectMapper.readValue(json, PasswordResetDraftRedisValue.class));
+		}catch(Exception e){
+			throw new BusinessException(RedisErrorCode.SERIALIZATION_ERROR);
+		}
+	}
+
+	/**
+	 * 업데이트 시 기존 TTL 유지
+	 */
+	public void updatePreserveTtl(PasswordResetDraftRedisValue value){
+		String redisKey = KEY_PREFIX + value.draftKey();
+		Long ttlSeconds = redis.getExpire(redisKey, TimeUnit.SECONDS);
+		if(ttlSeconds==null || ttlSeconds==-1){
+			// -2 : 키 없음
+			throw new BusinessException(RedisErrorCode.DRAFT_NOT_FOUND);
+		}
+		String json = toJson(value);
+		// 기존 TTL 유지하며 값 업데이트
+		// Duration.ofSeconds()는 초 단위 TTL 설정
+		redis.opsForValue().set(redisKey, json, Duration.ofSeconds(ttlSeconds));
+	}
+
+	private String toJson(PasswordResetDraftRedisValue value){
+		try {
+			// Object -> JSON 변환
+			// 동작원리:
+			// 1. ObjectMapper가 PasswordResetDraftRedisValue 객체의 필드들을 읽음
+			// 2. 각 필드의 값을 JSON 형식에 맞게 변환
+			// 3. 변환된 JSON 문자열을 반환
+			return redisObjectMapper.writeValueAsString(value);
+		} catch (Exception e) {
+			log.error("Redis Object to JSON 변환 실패", e);
+			throw new BusinessException(RedisErrorCode.SERIALIZATION_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetDraftService.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetDraftService.java
@@ -1,0 +1,56 @@
+package com.cotato.itda.domain.passwordreset.service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.cotato.itda.domain.passwordreset.config.PasswordResetProperties;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetDraftRedisValue;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetStep;
+import com.cotato.itda.domain.passwordreset.dto.response.PasswordResetCreateDraftResponse;
+import com.cotato.itda.domain.passwordreset.repository.PasswordResetDraftRedisRepository;
+import com.cotato.itda.domain.signup.repository.SignupDraftRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetDraftService {
+
+	private final PasswordResetProperties passwordResetProperties;
+	private final PasswordResetDraftRedisRepository passwordResetDraftRedisRepository;
+	// STEP1 : Draft 생성
+	public DraftCreationResult createDraft() {
+		// Draft Key 생성
+		String draftKey = UUID.randomUUID().toString();
+		log.info("Password Reset Draft Key 생성: {}", draftKey);
+
+		// PasswordResetDraftRedisValue 생성
+		PasswordResetDraftRedisValue redisValue =
+			PasswordResetDraftRedisValue.newDraft(draftKey);
+		log.info("Password Reset Redis 저장용 Draft 값 생성 완료");
+
+		// TTL 설정
+		Duration ttl = Duration.ofMinutes(passwordResetProperties.getDraftTtlMinutes()); // 10분
+		log.info("Password Reset Draft TTL 설정: {}분", ttl.toMinutes());
+
+		// Redis에 저장
+		passwordResetDraftRedisRepository.save(redisValue, ttl);
+		log.info("Password Reset Draft Redis 저장 완료: draftKey={}, TTL={}분", draftKey, ttl.toMinutes());
+
+		PasswordResetCreateDraftResponse response = new PasswordResetCreateDraftResponse(
+			PasswordResetStep.OTP_REQUIRED
+		);
+		log.info("Password Reset Draft 생성 응답 준비 완료: step={}", response.step());
+
+		return new DraftCreationResult(draftKey, response);
+	}
+
+	public record DraftCreationResult (
+		String draftKey,
+		PasswordResetCreateDraftResponse response
+	){}
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetOtpVerifyService.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetOtpVerifyService.java
@@ -1,0 +1,203 @@
+package com.cotato.itda.domain.passwordreset.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetDraftRedisValue;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetStep;
+import com.cotato.itda.domain.passwordreset.repository.PasswordResetDraftRedisRepository;
+import com.cotato.itda.domain.signup.dto.NextAction;
+import com.cotato.itda.domain.signup.dto.request.VerifyOtpRequest;
+import com.cotato.itda.domain.signup.dto.response.VerifyOtpResponse;
+import com.cotato.itda.global.error.constant.PasswordResetErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetOtpVerifyService {
+	private final PasswordResetDraftRedisRepository draftRedisRepository;
+
+	public VerifyOtpResponse verify(String draftKey, VerifyOtpRequest request) {
+		PasswordResetDraftRedisValue draft = draftRedisRepository.findByDraftKey(draftKey)
+			.orElseThrow(()-> new BusinessException(PasswordResetErrorCode.PASSWORD_RESET_DRAFT_NOT_FOUND));
+
+		// 2. step 검증
+		if(draft.step() == PasswordResetStep.PASSWORD_REQUIRED){
+			return successResponse(draft); // 이미 성공 상태
+		}
+
+		if (draft.step() != PasswordResetStep.OTP_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+
+		// OTP 상태가 없으면 Step2를 거치지 않았거나 Draft가 깨진 상태
+		if (draft.otpState() == null) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+		// ------------------------------------------------------------
+		// 3) SMS 발송을 이미 했는지 확인
+		// ------------------------------------------------------------
+		// Step3이 성공하면 아래 값들이 세팅되어야 한다.
+		// - otp.phone
+		// - otp.otpExpiresAt
+		// - otp.otpCodeHash
+		if (draft.otpState().phone() == null || draft.otpState().otpExpiresAt() == null || draft.otpState().otpCodeHash() == null) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+
+		OffsetDateTime now = OffsetDateTime.now();
+
+		// ------------------------------------------------------------
+		// 4) 만료 체크
+		// ------------------------------------------------------------
+		// - 만료된 OTP는 맞는 코드를 넣어도 실패로 처리
+		// - 만료된 경우 nextAction은 재전송 유도
+		if (now.isAfter(draft.otpState().otpExpiresAt())) {
+			// 만료면 보통 "재전송 가능" 상태로 돌려줌
+			// 현재는 resendAvailableAt == otpExpiresAt이므로
+			// otpExpiresAt 이후로 재전송 가능
+			PasswordResetDraftRedisValue expiredUpdated = PasswordResetDraftRedisValue.enableResendNowIfPossible(draft);
+
+			// 저장(상태를 바꿨을 수 있으니)
+			if (expiredUpdated != draft) {
+				draftRedisRepository.updatePreserveTtl(expiredUpdated);
+			}
+
+			return failureResponse(
+				expiredUpdated,
+				chooseNextActionForExpired(expiredUpdated)
+			);
+		}
+
+		// ------------------------------------------------------------
+		// 5) 시도 횟수 체크
+		// ------------------------------------------------------------
+		// attempts가 0이면 더 이상 verify를 받아주지 않고 재전송을 유도
+		if (draft.otpState().remainingOtpAttempts() <= 0) {
+			// attempts 0인 상태를 재전송 가능으로 켜줌
+			PasswordResetDraftRedisValue attemptsZeroUpdated = PasswordResetDraftRedisValue.enableResendNowIfPossible(draft);
+
+			if (attemptsZeroUpdated != draft) {
+				draftRedisRepository.updatePreserveTtl(attemptsZeroUpdated);
+			}
+
+			return failureResponse(
+				attemptsZeroUpdated,
+				chooseNextActionWhenNoAttempts(attemptsZeroUpdated)
+			);
+		}
+
+		// ------------------------------------------------------------
+		// 6) OTP 비교
+		// ------------------------------------------------------------
+		// - todo: 현재는 평문 비교, 실제로는 해시 비교
+		String  inputOtpCode = request.otpCode();
+		String draftOtpCodeHash = draft.otpState().otpCodeHash();
+		boolean match = inputOtpCode.equals(draftOtpCodeHash);
+
+		if (!match) {
+			// --------------------------------------------------------
+			// 7) 불일치: attempts 감소 + 상태 저장 + nextAction 결정
+			// --------------------------------------------------------
+			PasswordResetDraftRedisValue failed = draft.onOtpVerifyFailed();
+			draftRedisRepository.updatePreserveTtl(failed);
+
+			NextAction nextAction = chooseNextActionAfterFailed(failed);
+
+			return failureResponse(failed, nextAction);
+		}
+
+		// ------------------------------------------------------------
+		// 8) 일치(성공): PROFILE_REQUIRED로 전이 + 상태 저장
+		// ------------------------------------------------------------
+
+		PasswordResetDraftRedisValue verified = draft.onOtpVerified();
+		draftRedisRepository.updatePreserveTtl(verified);
+
+		return successResponse(verified);
+	}
+
+	private VerifyOtpResponse successResponse(PasswordResetDraftRedisValue draft) {
+		// 성공 응답
+		// step=PROFILE_REQUIRED
+		// flags.requiredFields=["name","birthDate"]
+
+		return new VerifyOtpResponse(
+			PasswordResetStep.PASSWORD_REQUIRED.name(),
+			new VerifyOtpResponse.Flags(
+				null,
+				null,
+				null,
+				null,
+				NextAction.GO_NEXT_STEP,
+				List.of("password")
+			)
+		);
+	}
+
+	private VerifyOtpResponse failureResponse(PasswordResetDraftRedisValue draft, NextAction nextAction) {
+		// 실패 응답 스펙:
+		// step=OTP_REQUIRED
+		// flags: canSendSms/resendAvailableAt/remainingOtpAttempts/otpExpiresAt/nextAction
+		return new VerifyOtpResponse(
+			PasswordResetStep.OTP_REQUIRED.name(),
+			new VerifyOtpResponse.Flags(
+				draft.otpState().canSendSms(),
+				draft.otpState().resendAvailableAt(),
+				draft.otpState().remainingOtpAttempts(),
+				draft.otpState().otpExpiresAt(),
+				nextAction,
+				null
+			)
+		);
+	}
+
+	/**
+	 * OTP 불일치로 실패 처리 후 nextAction 결정
+	 */
+	private NextAction chooseNextActionAfterFailed(PasswordResetDraftRedisValue draft) {
+		// remainingOtpAttempts > 0 : 아직 입력 재시도 가능
+		if (draft.otpState().remainingOtpAttempts() > 0) {
+			return NextAction.RETRY_OTP;
+		}
+
+		// attempts == 0 이 되었으면 재전송으로 유도
+		if (draft.otpState().remainingResendCount() > 0) {
+			// canSendSms=true로 켜져있으면 즉시 재전송 가능
+			if (draft.otpState().canSendSms()) return NextAction.REQUEST_RESEND_SMS;
+			return NextAction.WAIT_RESEND_WINDOW;
+		}
+
+		// 재전송도 불가면 가입 재시작
+		return NextAction.RESTART_PASSWORD_RESET;
+	}
+
+	/**
+	 * 만료된 경우 nextAction
+	 */
+	private NextAction chooseNextActionForExpired(PasswordResetDraftRedisValue draft) {
+		// 만료되었는데 재전송 횟수가 남아있으면 재전송
+		if (draft.otpState().remainingResendCount() > 0) {
+			if (draft.otpState().canSendSms()) return NextAction.REQUEST_RESEND_SMS;
+			return NextAction.WAIT_RESEND_WINDOW;
+		}
+		return NextAction.RESTART_PASSWORD_RESET;
+	}
+
+	/**
+	 * attempts가 0인 경우 nextAction
+	 */
+	private NextAction chooseNextActionWhenNoAttempts(PasswordResetDraftRedisValue draft) {
+		if (draft.otpState().remainingResendCount() > 0) {
+			if (draft.otpState().canSendSms()) return NextAction.REQUEST_RESEND_SMS;
+			return NextAction.WAIT_RESEND_WINDOW;
+		}
+		return NextAction.RESTART_PASSWORD_RESET;
+	}
+
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetPasswordService.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetPasswordService.java
@@ -1,0 +1,171 @@
+package com.cotato.itda.domain.passwordreset.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetDraftRedisValue;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetStep;
+import com.cotato.itda.domain.passwordreset.repository.PasswordResetDraftRedisRepository;
+import com.cotato.itda.domain.signup.dto.request.SubmitPasswordRequest;
+import com.cotato.itda.global.error.constant.PasswordResetErrorCode;
+import com.cotato.itda.global.error.constant.SignupErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetPasswordService {
+
+	private final PasswordResetDraftRedisRepository passwordResetDraftRedisRepository;
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	public Void resetPassword(
+		String draftKey,
+		SubmitPasswordRequest request
+	) {
+		PasswordResetDraftRedisValue draft = passwordResetDraftRedisRepository.findByDraftKey(draftKey)
+			.orElseThrow(()-> new BusinessException(PasswordResetErrorCode.PASSWORD_RESET_DRAFT_NOT_FOUND));
+		log.info("레디스 에서 조회된 Password Reset Draft: {}", draft);
+
+		if(draft.step() == PasswordResetStep.PASSWORD_RESET_COMPLETED) {
+			log.info("이미 STEP이 COMPLETED 상태, 멱등 처리로 종료");
+			return null;
+		}
+		//2. step 검증
+		if (draft.step() != PasswordResetStep.PASSWORD_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+		String phone = requireOtpPhone(draft);
+
+		String password = request.password();
+		String passwordConfirm = request.confirmPassword();
+		if (!password.equals(passwordConfirm)) {
+			throw new BusinessException(PasswordResetErrorCode.PASSWORD_MISMATCH);
+		}
+		log.info("비밀번호 일치 확인 완료");
+		validatePasswordPolicy(password);
+
+		if(!memberRepository.existsByPhoneNumber(phone)) {
+			throw new BusinessException(PasswordResetErrorCode.MEMBER_NOT_FOUND);
+		}
+		log.info("회원 존재 확인 완료");
+
+		String passwordHash  = passwordEncoder.encode(password);
+		log.info("비밀번호 해시 생성 완료");
+
+		try{
+			memberRepository.updatePasswordByPhoneNumber(passwordHash,phone);
+			log.info("비밀번호 재설정 완료");
+			PasswordResetDraftRedisValue completed = draft.onPasswordResetCompleted();
+			log.info("Password Reset Draft 상태 PASSWORD_RESET_COMPLETED로 전이 시도");
+			passwordResetDraftRedisRepository.updatePreserveTtl(completed);
+			log.info("Password Reset Draft 상태 PASSWORD_RESET_COMPLETED로 전이 완료");
+
+		} catch(Exception e) {
+			log.error("비밀번호 재설정 중 오류 발생: {}", e.getMessage());
+			throw new BusinessException(PasswordResetErrorCode.PASSWORD_RESET_FAILED);
+		}
+		return null;
+	}
+
+	public String requireOtpPhone(PasswordResetDraftRedisValue draft) {
+		if (draft.otpState() == null || draft.otpState().phone() == null || draft.otpState().phone().isBlank()) {
+			throw new BusinessException(SignupErrorCode.INVALID_SIGNUP_STEP);
+		}
+		return draft.otpState().phone();
+	}
+
+	/**
+	 * 비밀번호 정책 검증 메서드
+	 * <p>
+	 * [정책 요약]
+	 * 1) null 불가
+	 * 2) 길이: 8 ~ 64
+	 * 3) 공백 포함 불가
+	 * 4) 문자 종류(영문/숫자/특수문자) 중 최소 2종 이상 포함
+	 * <p>
+	 * [주의]
+	 * - 여기서 "문자"는 Character::isLetter 기준이라 한글도 letter로 잡힐 수 있음
+	 * (정확히 영문만 허용하려면 별도 정규식/범위 체크가 필요)
+	 */
+	private void validatePasswordPolicy(String password) {
+
+		// =========================
+		// 1) null 체크
+		// =========================
+		// - 회원가입/비밀번호 설정에서 password가 null이면 검증 자체가 불가능
+		// - 정책 위반으로 동일한 에러코드(INVALID_PASSWORD_POLICY)를 던짐
+		if (password == null) {
+			throw new BusinessException(SignupErrorCode.INVALID_PASSWORD_POLICY);
+		}
+
+		// =========================
+		// 2) 길이 제한 체크 (6~64)
+		// =========================
+		int len = password.length();
+		if (len < 6 || len > 64) {
+			throw new BusinessException(SignupErrorCode.INVALID_PASSWORD_POLICY);
+		}
+
+		// =========================
+		// 3) 공백 포함 여부 체크
+		// =========================
+		// - 공백이 들어가면 사용자가 "보이는 문자열"과 "실제 입력"이 달라질 수 있어
+		//   로그인 실패/혼란을 유발하기 쉽다.
+		// - 그래서 애초에 공백을 금지하는 정책
+		if (password.contains(" ")) {
+			throw new BusinessException(SignupErrorCode.INVALID_PASSWORD_POLICY);
+		}
+
+		// =========================
+		// 4) 문자 종류(영문/숫자/특수문자) 포함 여부 체크
+		// =========================
+
+		// 4-1) 영문(ASCII) 포함 여부
+		// - ASCII 영문자(A~Z, a~z)만 true로 인정하도록 범위를 체크한다.
+		boolean hasLetter = password.chars().anyMatch(ch ->
+			(ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+		);
+
+		// 4-2) ASCII 숫자만 포함 여부
+		// - 여기서는 '0'~'9' 사이 문자가 하나라도 있는지 확인한다.
+		boolean hasDigit = password.chars().anyMatch(ch -> ch >= '0' && ch <= '9');
+
+		// 4-3) 특수문자 포함 여부
+		boolean hasSpecial = password.chars().anyMatch(
+			ch -> "!@#$%^&*()_+-=[]{};':\",.<>/?\\|`~".indexOf(ch) >= 0
+		);
+
+		// =========================
+		// 5) "종류" 카운트 후 최소 2종 이상 요구
+		// =========================
+		// - hasLetter/hasDigit/hasSpecial 중 true인 개수를 센다.
+		// - 예: 영문만 있으면 1종 → 정책 위반
+		// - 예: 영문+숫자 있으면 2종 → 통과
+		// - 예: 숫자+특수문자 있으면 2종 → 통과
+		int kinds = 0;
+		if (hasLetter)
+			kinds++;
+		if (hasDigit)
+			kinds++;
+		if (hasSpecial)
+			kinds++;
+
+		// 최소 2종 미만이면 정책 위반
+		if (kinds < 2) {
+			throw new BusinessException(SignupErrorCode.INVALID_PASSWORD_POLICY);
+		}
+
+		// 여기까지 오면 정책 통과(예외 발생 없음)
+	}
+
+
+
+}

--- a/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetSmsService.java
+++ b/src/main/java/com/cotato/itda/domain/passwordreset/service/PasswordResetSmsService.java
@@ -1,0 +1,214 @@
+package com.cotato.itda.domain.passwordreset.service;
+
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetDraftRedisValue;
+import com.cotato.itda.domain.passwordreset.dto.PasswordResetStep;
+import com.cotato.itda.domain.passwordreset.dto.SendOtpRequest;
+import com.cotato.itda.domain.passwordreset.repository.PasswordResetDraftRedisRepository;
+import com.cotato.itda.domain.signup.dto.response.SendOtpSmsResponse;
+import com.cotato.itda.domain.sms.infra.solapi.SolapiFeignClient;
+import com.cotato.itda.domain.sms.infra.solapi.config.SolapiProperties;
+import com.cotato.itda.domain.sms.infra.solapi.dto.SolapiSendRequest;
+import com.cotato.itda.global.error.constant.PasswordResetErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetSmsService {
+	private final PasswordResetDraftRedisRepository passwordResetDraftRedisRepository;
+	private final MemberRepository memberRepository;
+
+	@Value("${signup.otp.length:6}")
+	private int otpLength;
+
+	@Value("${signup.otp.ttl-seconds:180}")
+	private long otpTtlSeconds;
+
+	@Value("${signup.otp.resend-window-seconds:180}")
+	private long resendWindowSeconds;
+
+	private final SolapiProperties solapiProperties;
+	private final SolapiFeignClient solapiFeignClient;
+	// - 암호학적으로 안전한 난수 생성기
+	// - OTP 생성 시 예측 불가능한 난수를 생성하여 보안성을 높임
+	private final SecureRandom secureRandom = new SecureRandom();
+	/**
+	 * STEP2 동작 흐름
+	 * <p>
+	 * 1. draftKey 유효성/존재 확인
+	 * 2. 현재 stetp 확인(OTP_REQUIRED에서만 허용)
+	 * 3. 재전송 가능 시간 (resendAvailableAt) 체크
+	 * 4. sms SendCound 상한 체크(무한 발송 방지)
+	 * 5. phone 정규화(숫자만 남김) + 검증
+	 * 6. OTP 생성
+	 * 7. Redis에 OTP 해시/만료/카운트 저장
+	 * 8. SOLAPI로 문자 발송
+	 * 9. 응답 DTO 구성
+	 */
+	public SendOtpSmsResponse sendOtpSms(String draftKey, SendOtpRequest request) {
+
+		// 1. draftKey 유효성/존재 확인
+		PasswordResetDraftRedisValue draft = passwordResetDraftRedisRepository.findByDraftKey(draftKey)
+			.orElseThrow(() -> new BusinessException(PasswordResetErrorCode.PASSWORD_RESET_DRAFT_NOT_FOUND));
+
+		// 2. 현재 stetp 확인(OTP_REQUIRED에서만 허용)
+		if (draft.step() != PasswordResetStep.OTP_REQUIRED) {
+			throw new BusinessException(PasswordResetErrorCode.INVALID_PASSWORD_RESET_STEP);
+		}
+
+		// canSendSms가 false인 경우, 재전송 가능하도록 상태 변경
+		draft = PasswordResetDraftRedisValue.enableResendNowIfPossible(draft);
+
+		// 3. 재전송 가능 시간 (resendAvailableAt) 체크
+		// UTC 기준의 현재 시각 ( 예: 2026-01-01T12:00:00Z )
+		// ZoneOffset.UTC를 붙인 이유
+		// - 서버가 어느 지역에 있든지 상관없이 항상 UTC 기준으로 시간을 맞추기 위해
+		// - 만약 인자가 없다면 서버 JVM의 기본 타임존 설정을 따름
+		// - 서버가 특정 타임존에 설정되어 있을 경우, 의도치 않은 시간대 차이로 인해 시간 계산이 틀어질 수 있음
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		// canSendSms가 false인 동안은 resendAvailableAt 이전에 재전송 불가
+		if (!draft.otpState().canSendSms() && draft.otpState().resendAvailableAt() != null && now.isBefore(
+			draft.otpState().resendAvailableAt())) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_RESEND_NOT_AVAILABLE_YET);
+		}
+
+		// 4. sms SendCound 상한 체크(무한 발송 방지)
+		// remainingResendCount가 0 이하이면 재전송 불가
+		if (draft.otpState().remainingResendCount() <= 0) {
+			throw new BusinessException(PasswordResetErrorCode.OTP_RESEND_LIMIT_EXCEEDED);
+		}
+
+		// 5. phone 정규화(숫자만 남김) + 검증
+		// SOLAPI는 특수문자 없이 숫자만 형태를 받아야 함
+		String normalizedPhone = normalizePhone(request.phoneNumber());
+		validatePhone(normalizedPhone);
+
+		// phoneNumber로 memberId 조회 및 검증
+		Member member = memberRepository.findByPhoneNumberAndName(normalizedPhone,request.name())
+			.orElseThrow(() -> new BusinessException(PasswordResetErrorCode.MEMBER_NOT_FOUND, Map.of("phoneNumber", normalizedPhone)));
+
+		// OTP 코드 생성
+		String otpCode = generateNumericOtp(otpLength);
+
+		// todo: OTP 해시 저장
+		// 현재는 "2341" 그대로 저장하지만, 실제로는 해시 변환 필요
+
+		// 6. 만료/재전송 가능 시간 계산
+		// OTP 만료 시간 = 현재 시각 + OTP TTL
+		OffsetDateTime otpExpiresAt = now.plusSeconds(otpTtlSeconds); // 3분 후 만료
+		log.info("OTP Expires At: {}", otpExpiresAt);
+		// 현재는 만료 지나면 재전송 가능 => resendAvailableAt = otpExpiresAt
+		OffsetDateTime resendAvailableAt = now.plusSeconds(resendWindowSeconds);
+		log.info("OTP Resend Available At: {}", resendAvailableAt);
+
+		//  실패 시 롤백용 이전 상태
+		PasswordResetDraftRedisValue beforeReserveDraft = draft;
+		// 7. OTP 생성
+		PasswordResetDraftRedisValue updated = draft.onSmsSent(
+			normalizedPhone,
+			member.getId(),
+			resendAvailableAt,
+			otpExpiresAt,
+			otpCode
+		);
+
+		// 7. Redis에 OTP 해시/만료/카운트 저장
+		passwordResetDraftRedisRepository.updatePreserveTtl(updated);
+		// 8. SOLAPI로 문자 발송
+		try {
+			String text = "[심톡] 인증번호는 " + otpCode + " 입니다. " + (otpTtlSeconds / 60) + "분 내 입력해주세요.";
+
+			log.info("Sending OTP SMS to {}: {}", normalizedPhone, text);
+			SolapiSendRequest solapiReq = new SolapiSendRequest(
+				List.of(new SolapiSendRequest.Message(
+					solapiProperties.defaultFrom(),
+					normalizedPhone,
+					text
+				))
+			);
+			log.info("SOLAPI Request: {}", solapiReq.toString());
+
+			solapiFeignClient.sendManyDetail(solapiReq);
+			log.info("OTP SMS sent successfully to {}", normalizedPhone);
+		} catch (FeignException ex) {
+			// 실패하면 사용자 입장에서 "보낸 적 없다"가 되어야 하므로,
+			// 그래서 canSendSms를 true로 풀고, otp 정보를 무효화해 재시도 가능하게 만드는 전략을 쓴다.
+			log.info("Failed to send OTP SMS to {}: {}", normalizedPhone, ex.getMessage());
+			try {
+				passwordResetDraftRedisRepository.updatePreserveTtl(beforeReserveDraft);
+			} catch (Exception rollbackEx) {
+				// 롤백마저 실패하면 사용자는 쿨타임 걸린 것처럼 보일 수 있다.
+				// 운영 대응을 위해 로그를 남긴다.
+				log.error("OTP send failed and rollback also failed. draftKey={}", draftKey, rollbackEx);
+			}
+
+			throw new BusinessException(PasswordResetErrorCode.OTP_SMS_SEND_FAILED, Map.of("solapiStatus", ex.status()));
+		}
+
+		// 9) 응답
+		return new SendOtpSmsResponse(
+			"OTP_REQUIRED",
+			new SendOtpSmsResponse.Flags(
+				updated.otpState().canSendSms(),
+				updated.otpState().resendAvailableAt(),
+				updated.otpState().otpExpiresAt(),
+				updated.otpState().smsSendCount(),
+				updated.otpState().remainingResendCount(),
+				updated.otpState().remainingOtpAttempts()
+			)
+		);
+	}
+
+	public String normalizePhone(String phoneNumber) {
+		if (phoneNumber == null) {
+			return null;
+		}
+		// 숫자 이외의 문자 제거
+		return phoneNumber.replaceAll("[^0-9]", "");
+	}
+
+	public void validatePhone(String phoneNumber) {
+		if(phoneNumber == null || phoneNumber.isBlank()){
+			//핸드폰 번호는 필수 입력 에러
+			throw new BusinessException(PasswordResetErrorCode.OTP_PHONE_NUMBER_REQUIRED);
+		}
+		// 한국 휴대폰 번호 형식 검증 (예: 01012345678)
+		if(!phoneNumber.matches("^010\\d{8}$")){
+			throw new BusinessException(PasswordResetErrorCode.OTP_PHONE_NUMBER_REQUIRED, Map.of("유효한 한국 휴대폰 번호 형식이 아닙니다.", phoneNumber));
+		}
+	}
+
+	/**
+	 *  숫자 OTP (일회용 인증번호) 생성
+	 *  - length=4  → 0000 ~ 9999 범위의 문자열
+	 */
+	private String generateNumericOtp(int length) {
+		// length=4이면 0000~9999
+		int bound = (int) Math.pow(10, length);
+		// 난수 생성: 0 이상 bound 미만의 정수
+		// length=4 라면 value가 0, 1, 2, ..., 9999 중 하나
+		int value = secureRandom.nextInt(bound);
+
+		// 0으로 시작하는 경우를 대비해, 고정 길이 문자열로 포맷팅
+		// 예: length=4, value=7  → "0007"
+		// 예: length=4, value=123 → "0123"
+		// 예: length=4, value=9999 → "9999"
+		return String.format("%0" + length + "d", value);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/signup/config/SignupProperties.java
+++ b/src/main/java/com/cotato/itda/domain/signup/config/SignupProperties.java
@@ -1,4 +1,4 @@
-package com.cotato.itda.domain.signup.service;
+package com.cotato.itda.domain.signup.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/cotato/itda/domain/signup/dto/NextAction.java
+++ b/src/main/java/com/cotato/itda/domain/signup/dto/NextAction.java
@@ -5,5 +5,6 @@ public enum NextAction {
 	REQUEST_RESEND_SMS,  // OTP 만료/재발송 필요 → SMS 재발송 요청 버튼/흐름으로 유도
 	WAIT_RESEND_WINDOW,  // 재발송 쿨타임 중 → resendAvailableAt까지 대기(버튼 비활성/카운트다운)
 	RESTART_SIGNUP,      // draft 만료/상태 불일치 등 → 회원가입 흐름을 처음부터 다시 시작
-	GO_NEXT_STEP         // OTP 검증 성공 → 다음 단계(프로필/비밀번호 등)로 진행
+	GO_NEXT_STEP,         // OTP 검증 성공 → 다음 단계(프로필/비밀번호 등)로 진행
+	RESTART_PASSWORD_RESET // 비밀번호 재설정 전체 과정 처음부터 다시 시작
 }

--- a/src/main/java/com/cotato/itda/domain/signup/service/SignupDraftService.java
+++ b/src/main/java/com/cotato/itda/domain/signup/service/SignupDraftService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.cotato.itda.domain.signup.config.SignupProperties;
 import com.cotato.itda.domain.signup.dto.response.CreateDraftResponse;
 import com.cotato.itda.domain.signup.dto.SignupDraftRedisValue;
 import com.cotato.itda.domain.signup.dto.TermsItem;

--- a/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
@@ -66,7 +66,8 @@ public class SecurityConfig {
 					"/api/auth/login",
 					"/api/auth/refresh",
 					"/swagger-ui/**",
-					"/v3/api-docs/**"
+					"/v3/api-docs/**",
+					"/api/password-reset/**"
 				).permitAll()
 				//관리자 전용 URL 패턴
 				//                        .requestMatchers(

--- a/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
@@ -75,6 +75,15 @@ public class SwaggerConfig {
             .build();
     }
     @Bean
+    public GroupedOpenApi passwordResetApi() {
+        return GroupedOpenApi.builder()
+            .group("PasswordReset")
+            .displayName("PasswordReset API")
+            .packagesToScan("com.cotato.itda.domain.passwordreset.controller")
+            .pathsToMatch("/api/password-reset/**")
+            .build();
+    }
+    @Bean
     public GroupedOpenApi MemberApi() {
         return GroupedOpenApi.builder()
             .group("Member")

--- a/src/main/java/com/cotato/itda/global/error/constant/PasswordResetErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/PasswordResetErrorCode.java
@@ -1,0 +1,135 @@
+package com.cotato.itda.global.error.constant;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PasswordResetErrorCode implements ErrorCode {
+
+	PASSWORD_RESET_FAILED(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"비밀번호 재설정에 실패했습니다. 다시 시도해주세요.",
+		"PASSWORD_RESET_ERROR_500_PASSWORD_RESET_FAILED"
+	),
+	INVALID_PASSWORD_RESET_STEP(
+		HttpStatus.BAD_REQUEST,
+		"현재 단계에서 허용되지 않는 작업입니다.",
+		"PASSWORD_RESET_ERROR_400_INVALID_PASSWORD_RESET_STEP"
+	),
+	MEMBER_ID_NOT_SET(
+		HttpStatus.BAD_REQUEST,
+		"사용자 ID가 설정되지 않았습니다.",
+		"PASSWORD_RESET_ERROR_400_MEMBER_ID_NOT_SET"
+	),
+	MEMBER_NOT_FOUND(
+		HttpStatus.NOT_FOUND,
+		"해당하는 사용자를 찾을 수 없습니다.",
+		"PASSWORD_RESET_ERROR_404_MEMBER_NOT_FOUND"
+	),
+	// ----------------------------
+	// OTP / SMS
+	// ----------------------------
+	OTP_STATE_NOT_FOUND(
+		HttpStatus.NOT_FOUND,
+		"인증번호 상태 정보를 찾을 수 없습니다.",
+		"PASSWORD_RESET_ERROR_404_OTP_STATE_NOT_FOUND"
+	),
+	OTP_PHONE_NUMBER_REQUIRED(
+		HttpStatus.BAD_REQUEST,
+		"핸드폰 번호는 필수 입력입니다.",
+		"PASSWORD_RESET_ERROR_400_OTP_PHONE_NUMBER_REQUIRED"
+	),
+	OTP_SMS_SEND_FAILED(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"인증번호 발송에 실패했습니다.",
+		"PASSWORD_RESET_ERROR_500_OTP_SMS_SEND_FAILED"
+	),
+	OTP_RESEND_NOT_AVAILABLE_YET(
+		HttpStatus.BAD_REQUEST,
+		"지금은 인증번호 재전송이 불가능합니다. 잠시 후 다시 시도해주세요.",
+		"PASSWORD_RESET_ERROR_400_OTP_RESEND_NOT_AVAILABLE_YET"
+	),
+	OTP_RESEND_LIMIT_EXCEEDED(
+		HttpStatus.BAD_REQUEST,
+		"인증번호 재전송 시도 횟수를 초과했습니다.",
+		"PASSWORD_RESET_ERROR_400_OTP_RESEND_LIMIT_EXCEEDED"
+	),
+	OTP_EXPIRED(
+		HttpStatus.BAD_REQUEST,
+		"인증번호가 만료되었습니다. 다시 요청해주세요.",
+		"PASSWORD_RESET_ERROR_400_OTP_EXPIRED"
+	),
+	OTP_INVALID(
+		HttpStatus.BAD_REQUEST,
+		"인증번호가 올바르지 않습니다.",
+		"PASSWORD_RESET_ERROR_400_OTP_INVALID"
+	),
+	OTP_ATTEMPTS_EXCEEDED(
+		HttpStatus.BAD_REQUEST,
+		"인증번호 입력 시도 횟수를 초과했습니다. 다시 요청해주세요.",
+		"PASSWORD_RESET_ERROR_400_OTP_ATTEMPTS_EXCEEDED"
+	),
+
+	// ----------------------------
+	// Draft / Step
+	// ----------------------------
+	PASSWORD_RESET_DRAFT_NOT_FOUND(
+		HttpStatus.NOT_FOUND,
+		"비밀번호 재설정 진행 정보를 찾을 수 없습니다.",
+		"PASSWORD_RESET_ERROR_404_PASSWORD_RESET_DRAFT_NOT_FOUND"
+	),
+	PHONE_NOT_VERIFIED(
+		HttpStatus.BAD_REQUEST,
+		"전화번호 인증이 필요합니다.",
+		"PASSWORD_RESET_ERROR_400_PHONE_NOT_VERIFIED"
+	),
+
+	// ----------------------------
+	// Password
+	// ----------------------------
+	PASSWORD_REQUIRED(
+		HttpStatus.BAD_REQUEST,
+		"비밀번호가 필요합니다.",
+		"PASSWORD_RESET_ERROR_400_PASSWORD_REQUIRED"
+	),
+	PASSWORD_MISMATCH(
+		HttpStatus.BAD_REQUEST,
+		"비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+		"PASSWORD_RESET_ERROR_400_PASSWORD_MISMATCH"
+	),
+	INVALID_PASSWORD_POLICY(
+		HttpStatus.BAD_REQUEST,
+		"비밀번호가 정책에 맞지 않습니다.",
+		"PASSWORD_RESET_ERROR_400_INVALID_PASSWORD_POLICY"
+	),
+	PASSWORD_REUSE_NOT_ALLOWED(
+		HttpStatus.BAD_REQUEST,
+		"기존 비밀번호와 동일하게 설정할 수 없습니다.",
+		"PASSWORD_RESET_ERROR_400_PASSWORD_REUSE_NOT_ALLOWED"
+	),
+
+	// ----------------------------
+	// Abuse / Common
+	// ----------------------------
+	RATE_LIMIT_EXCEEDED(
+		HttpStatus.TOO_MANY_REQUESTS,
+		"요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+		"PASSWORD_RESET_ERROR_429_RATE_LIMIT_EXCEEDED"
+	),
+
+	// ----------------------------
+	// Security / Account state (계정 열거 방지용 중립 메시지)
+	// ----------------------------
+	ACCOUNT_NOT_AVAILABLE(
+		HttpStatus.BAD_REQUEST,
+		"비밀번호를 재설정할 수 없습니다. 인증 정보를 확인해주세요.",
+		"PASSWORD_RESET_ERROR_400_ACCOUNT_NOT_AVAILABLE"
+	);
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -58,6 +58,9 @@ signup:
     resend-windows-seconds: 60
   draft-ttl-minutes: 60
 
+password-reset:
+  draft-ttl-minutes: 60
+
 jwt:
   access:
     algorithm: HS256


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #37 

## 📝 작업 내용
비밀번호 재설정 플로우를 Draft 기반으로 추가했습니다.
Step1에서 Draft를 발급하고, Step2에서 SMS OTP 발송, Step3에서 OTP 검증 후 Step4에서 새 비밀번호를 설정하는 흐름입니다.
진행 상태는 Redis Draft에 저장하고 TTL로 만료 처리합니다.

## 🔍 주요 변경 사항
- Password Reset 도메인 추가
  - Draft 생성 API: `/api/password-reset/drafts`
  - SMS 발송 API: `/api/password-reset/sms/send`
  - OTP 검증 API: `/api/password-reset/otp/verify`
  - 비밀번호 변경 API: `/api/password-reset/password`
- Redis Draft 저장소 추가
  - `PasswordResetDraftRedisValue`로 상태(step, otpState 등) 관리
  - TTL 유지 업데이트(`updatePreserveTtl`) 지원
- SMS 발송 연동
  - Solapi 기반 OTP 발송
  - OTP 만료/재전송 윈도우/시도 횟수 제한 로직 포함
- 비밀번호 변경 반영
  - `MemberRepository`에 phoneNumber 기준 passwordHash 업데이트 쿼리 추가
- 설정/문서화
  - `SecurityConfig`에 `/api/password-reset/**` permitAll 추가
  - `SwaggerConfig`에 PasswordReset API group 추가
  - `application-local.yml`에 `password-reset.draft-ttl-minutes` 추가
- 빌드 설정
  - QueryDSL generated output 디렉토리 설정 정리(Gradle 최신 방식)

## 🧪 테스트/검증
- 로컬에서 Draft 생성 → OTP 발송 → OTP 검증 → 비밀번호 변경까지 플로우 동작 확인
- Redis Draft TTL 동작 확인
- Swagger에 PasswordReset 그룹 노출 확인

## ⚠️ 영향 범위
- API 변경: 있음 (password-reset 신규 엔드포인트)
- DB 변경: 없음 (schema 변경 없음)
- Redis/외부연동: 있음 (Redis draft 저장 + Solapi SMS)
- 설정 변경: 있음 (`password-reset.draft-ttl-minutes` 추가)
