### PR TITLE
[Feat] 시듦 스케쥴러 추가 / 식물 조회, 영양제, 물주기 시 밀린 페널티 적용

### DIFF
--- a/src/main/java/com/cotato/itda/ItdaApplication.java
+++ b/src/main/java/com/cotato/itda/ItdaApplication.java
@@ -3,9 +3,11 @@ package com.cotato.itda;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients(basePackages = "com.cotato.itda")
+@EnableScheduling
 public class ItdaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
+++ b/src/main/java/com/cotato/itda/domain/garden/entity/SharedPlant.java
@@ -63,12 +63,17 @@ public class SharedPlant extends BaseEntity {
     @Builder.Default
     private boolean isPlanted = false;
 
+    @Column(name = "applied_penalty", nullable = false)
+    @Builder.Default
+    private int appliedPenalty = 0;
+
     public boolean water(int growthValue, Member member) {
         PlantStage previousStage = this.growthStage;
         this.growthValue += growthValue;
         this.growthStage = this.plant.calculateGrowthStage(this.growthValue);
         this.lastWateredBy = member.getId();
         this.lastWateredAt = LocalDateTime.now();
+        this.appliedPenalty = 0;
         return this.growthStage != previousStage;
     }
 
@@ -95,5 +100,20 @@ public class SharedPlant extends BaseEntity {
 
     public void plant() {
         this.isPlanted = true;
+    }
+
+    public void applyPenalty(int penalty) {
+        this.growthValue = Math.max(0, this.growthValue - penalty);
+        this.appliedPenalty += penalty;
+        this.growthStage = this.plant.calculateGrowthStage(this.growthValue);
+    }
+
+    public void applyMissedPenalty(int expectedPenalty) {
+        int diff = expectedPenalty - this.appliedPenalty;
+        if (diff > 0) {
+            this.growthValue = Math.max(0, this.growthValue - diff);
+            this.appliedPenalty += diff;
+            this.growthStage = this.plant.calculateGrowthStage(this.growthValue);
+        }
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -25,4 +25,6 @@ public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> 
             "AND sp.status IN :statuses " +
             "ORDER BY sp.createdAt DESC")
     List<SharedPlant> findAllByMemberIdAndStatusIn(@Param("memberId") Long memberId, @Param("statuses") List<SharedPlantStatus> statuses);
+
+    List<SharedPlant> findAllByStatusAndIsPlantedTrue(SharedPlantStatus status);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/scheduler/WitheredPenaltyScheduler.java
+++ b/src/main/java/com/cotato/itda/domain/garden/scheduler/WitheredPenaltyScheduler.java
@@ -1,0 +1,36 @@
+package com.cotato.itda.domain.garden.scheduler;
+
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.garden.service.GardenStateCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WitheredPenaltyScheduler {
+
+    private final SharedPlantRepository sharedPlantRepository;
+    private final GardenStateCalculator gardenStateCalculator;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void applyWitheredPenalty() {
+        List<SharedPlant> plants = sharedPlantRepository
+                .findAllByStatusAndIsPlantedTrue(SharedPlantStatus.GROWING);
+
+        for (SharedPlant plant : plants) {
+            int expectedPenalty = gardenStateCalculator.calculateExpectedPenalty(plant);
+            int diff = expectedPenalty - plant.getAppliedPenalty();
+
+            if (diff > 0) {
+                plant.applyPenalty(diff);
+            }
+        }
+    }
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/GardenStateCalculator.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/GardenStateCalculator.java
@@ -45,7 +45,25 @@ public class GardenStateCalculator {
         int bloomMax = plant.getPlant().getBloomMax();
         if (bloomMax <= 0) return 0;
 
-        int percentage = (plant.getGrowthValue() * 100) / bloomMax;
+        int effectiveGrowth = calculateEffectiveGrowthValue(plant);
+        int percentage = (effectiveGrowth * 100) / bloomMax;
         return Math.min(percentage, 100);
+    }
+
+    public int calculateExpectedPenalty(SharedPlant plant) {
+        if (plant.getLastWateredAt() == null) return 0;
+
+        long hours = ChronoUnit.HOURS.between(plant.getLastWateredAt(), LocalDateTime.now());
+
+        if (hours >= 120) return 20;
+        else if (hours >= 96) return 10;
+        else if (hours >= 72) return 5;
+        return 0;
+    }
+
+    public int calculateEffectiveGrowthValue(SharedPlant plant) {
+        int expectedPenalty = calculateExpectedPenalty(plant);
+        int pendingPenalty = expectedPenalty - plant.getAppliedPenalty();
+        return Math.max(plant.getGrowthValue() - pendingPenalty, 0);
     }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantCommandServiceImpl.java
@@ -75,6 +75,10 @@ public class SharedPlantCommandServiceImpl implements SharedPlantCommandService 
         // 영양제 주기 가능 여부 검증
         sharedPlantValidator.validateCanGiveNutrient(sharedPlant, member);
 
+        // 밀린 페널티 적용
+        int expectedPenalty = gardenStateCalculator.calculateExpectedPenalty(sharedPlant);
+        sharedPlant.applyMissedPenalty(expectedPenalty);
+
         // 혼자 돌봄 모드 -> 공동 돌봄 모드로
         if (sharedPlant.getIsSoloMode() && !memberId.equals(sharedPlant.getSoloPowerMemberId())) {
             sharedPlant.exitSoloMode();


### PR DESCRIPTION
## #️⃣연관된 이슈

#83 

## 📝작업 내용

- 시듦 스케쥴러 추가
- 식물 조회 시 밀린 페널티를 조회하여 응답 `percentage` 필드에 반영
- 식물 영양제 주기 시 밀린 페널티를 `SharedPlant` 엔티티의 `growthValue`와 `appliedPenalty`에 반영
- 식물 물주기 시 `SharedPlant` 엔티티의 `appliedPenalty` 초기화

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
