### PR TITLE
[refactor] 일기 상세 조회 권한 예외 처리 제거

### DIFF
--- a/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
@@ -53,20 +53,19 @@ public class DiaryQueryService {
         boolean isMe = writer.getId().equals(memberId);
         String nickname;
 
-//        if (isMe) {
-//            nickname = writer.getName();
-//        } else {
-//            // 작성자가 친구 관계인지 확인
-//            Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
-//                    .orElseThrow(() -> new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN));
-//
-//            nickname = friendship.getDisplayName();
-//        }
+        if (isMe) {
+            nickname = writer.getName();
+        } else {
+            // 작성자가 친구 관계인지 확인
+            nickname = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
+                    .map(Friendship::getDisplayName) // 친구면 설정한 친구 닉네임
+                    .orElse(writer.getName()); // 친구가 아니면 기존 이름
+        }
 
         // 좋아요 여부 판별
         boolean isLiked = diaryLikeRepository.existsByDiaryIdAndMemberId(diaryId, memberId);
 
-        WriterInfo diaryWriterInfo = DiaryConverter.toWriterInfo(writer, writer.getName(), isMe);
+        WriterInfo diaryWriterInfo = DiaryConverter.toWriterInfo(writer, nickname, isMe);
         return DiaryConverter.toDetailResponse(diary, diaryWriterInfo, isLiked);
     }
 

--- a/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryQueryService.java
@@ -53,20 +53,20 @@ public class DiaryQueryService {
         boolean isMe = writer.getId().equals(memberId);
         String nickname;
 
-        if (isMe) {
-            nickname = writer.getName();
-        } else {
-            // 작성자가 친구 관계인지 확인
-            Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
-                    .orElseThrow(() -> new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN));
-
-            nickname = friendship.getDisplayName();
-        }
+//        if (isMe) {
+//            nickname = writer.getName();
+//        } else {
+//            // 작성자가 친구 관계인지 확인
+//            Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, writer.getId(), FriendshipStatus.ACTIVE)
+//                    .orElseThrow(() -> new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN));
+//
+//            nickname = friendship.getDisplayName();
+//        }
 
         // 좋아요 여부 판별
         boolean isLiked = diaryLikeRepository.existsByDiaryIdAndMemberId(diaryId, memberId);
 
-        WriterInfo diaryWriterInfo = DiaryConverter.toWriterInfo(writer, nickname, isMe);
+        WriterInfo diaryWriterInfo = DiaryConverter.toWriterInfo(writer, writer.getName(), isMe);
         return DiaryConverter.toDetailResponse(diary, diaryWriterInfo, isLiked);
     }
 

--- a/src/main/java/com/cotato/itda/domain/profile/dto/response/ProfileResponse.java
+++ b/src/main/java/com/cotato/itda/domain/profile/dto/response/ProfileResponse.java
@@ -6,6 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record ProfileResponse(
+
+        @Schema(description = "멤버 ID", example = "1")
+        Long memberId,
+
         @Schema(description = "프로필 이미지 URL", example = "https://...amazonaws.com/profile/uuid_filename.png")
         String profileImageUrl,
 
@@ -20,6 +24,7 @@ public record ProfileResponse(
 ) {
     public static ProfileResponse from(Member member) {
         return new ProfileResponse(
+                member.getId(),
                 member.getProfileImageUrl(),
                 member.getName(),
                 member.getPhoneNumber(),


### PR DESCRIPTION
## #️⃣연관된 이슈
#86 
<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->

## 📝작업 내용
- DiaryQueryService의 일기 상세 조회 메서드에서 권한 예외 처리 제거
- 프로필 조회 응답에 memberId 포함하도록 수정
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
