### PR TITLE
[feat] 홈 위젯용 공유 식물 조회 API 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantController.java
@@ -56,4 +56,11 @@ public class SharedPlantController implements SharedPlantControllerDocs {
     ) {
         return ApiResponse.success(sharedPlantCommandService.plantSeed(sharedPlantId, jwtPrincipal.memberId()));
     }
+
+    @GetMapping("/widget")
+    public ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getWidgetSharedPlants(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal
+    ) {
+        return ApiResponse.success(sharedPlantQueryService.getWidgetSharedPlants(jwtPrincipal.memberId()));
+    }
 }

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public interface SharedPlantControllerDocs {
 
-    @Operation(summary = "공유 식물 목록 조회 API By 정원", description = "상태별로 공유 식물 목록을 조회합니다. ?status=GROWING&status=WITHERED 또는 ?status=COMPLETED 형태로 조회합니다. status를 지정하지 않으면 기본값으로 GROWING, WITHERED를 조회합니다.")
+    @Operation(summary = "공유 식물 목록 조회 API By 정원", description = "상태별로 공유 식물 목록을 조회합니다. ?status=GROWING 또는 ?status=COMPLETED 형태로 조회합니다. status를 지정하지 않으면 기본값으로 GROWING을 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
@@ -28,7 +28,7 @@ public interface SharedPlantControllerDocs {
     ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getSharedPlants(
             @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
             @Parameter(
-                    description = "조회할 상태 목록 (GROWING, WITHERED, COMPLETED). 미지정 시 기본값: GROWING, WITHERED",
+                    description = "조회할 상태 목록 (GROWING, COMPLETED). 미지정 시 기본값: GROWING",
                     array = @ArraySchema(schema = @Schema(implementation = SharedPlantStatus.class))
             )
             @RequestParam(name = "status", required = false) List<SharedPlantStatus> statuses

--- a/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
+++ b/src/main/java/com/cotato/itda/domain/garden/controller/SharedPlantControllerDocs.java
@@ -97,4 +97,28 @@ public interface SharedPlantControllerDocs {
             @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
             @Parameter(description = "공유 식물 ID") @PathVariable(name = "sharedPlantId") Long sharedPlantId
     );
+
+    @Operation(summary = "홈 위젯용 공유 식물 조회 API", description = """
+            홈 위젯에 표시할 공유 식물 목록을 조회합니다.
+
+            **필터링 조건:**
+            - GROWING 상태이면서 씨앗이 심어진 식물만 조회
+            - 활성 친구 관계인 경우만 포함
+            - WATERABLE, WITHERED, WATERED_RECENTLY 상태만 반환
+
+            **제외되는 상태:**
+            - COMPLETED (완료)
+            - SEED_READY (씨앗 미심음)
+            - NUTRITION_AVAILABLE (72h+ 경과)
+            - AFTER_NUTRITION (영양제 투여 후)
+            - GROWING (24h 내 stageChanged)
+            """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/widget")
+    ApiResponse<SharedPlantResDTO.SharedPlantInfoListDTO> getWidgetSharedPlants(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal
+    );
 }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -27,4 +27,11 @@ public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> 
     List<SharedPlant> findAllByMemberIdAndStatusIn(@Param("memberId") Long memberId, @Param("statuses") List<SharedPlantStatus> statuses);
 
     List<SharedPlant> findAllByStatusAndIsPlantedTrue(SharedPlantStatus status);
+
+    @Query("SELECT sp FROM SharedPlant sp " +
+            "WHERE (sp.memberA.id = :memberId OR sp.memberB.id = :memberId) " +
+            "AND sp.status = com.cotato.itda.domain.garden.enums.SharedPlantStatus.GROWING " +
+            "AND sp.isPlanted = true " +
+            "ORDER BY sp.createdAt DESC")
+    List<SharedPlant> findAllGrowingAndPlantedByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryService.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface SharedPlantQueryService {
     SharedPlantResDTO.SharedPlantInfoListDTO getSharedPlants(Long memberId, List<SharedPlantStatus> statuses);
+
+    SharedPlantResDTO.SharedPlantInfoListDTO getWidgetSharedPlants(Long memberId);
 }

--- a/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/query/SharedPlantQueryServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -84,6 +85,67 @@ public class SharedPlantQueryServiceImpl implements SharedPlantQueryService {
                             sp, pair.friendship(), memberId, gardenState, percentage
                     );
                 })
+                .toList();
+
+        return SharedPlantConverter.toSharedPlantInfoListDTO(sharedPlantInfoDTOs, member.getNutrientCount());
+    }
+
+    @Override
+    public SharedPlantResDTO.SharedPlantInfoListDTO getWidgetSharedPlants(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 1. GROWING + isPlanted=true 식물 조회
+        List<SharedPlant> sharedPlants = sharedPlantRepository
+                .findAllGrowingAndPlantedByMemberId(memberId);
+
+        if (sharedPlants.isEmpty()) {
+            return SharedPlantResDTO.SharedPlantInfoListDTO.builder()
+                    .totalCount(0)
+                    .nutrientCount(member.getNutrientCount())
+                    .sharedPlants(List.of())
+                    .build();
+        }
+
+        // 2. 각 공유 식물에서 친구 ID 추출
+        List<Long> friendIds = sharedPlants.stream()
+                .map(sp -> sp.getMemberA().getId().equals(memberId)
+                        ? sp.getMemberB().getId()
+                        : sp.getMemberA().getId())
+                .toList();
+
+        // 3. Friendship 조회 후 Map으로 변환
+        List<Friendship> friendships = friendshipRepository.findAllByMember_IdAndFriend_IdInAndStatus(
+                memberId, friendIds, FriendshipStatus.ACTIVE);
+
+        Map<Long, Friendship> friendshipMap = friendships.stream()
+                .collect(Collectors.toMap(Friendship::getFriendId, f -> f));
+
+        // 4. 위젯 대상 상태 정의
+        Set<GardenState> widgetStates = Set.of(
+                GardenState.WATERABLE,
+                GardenState.WITHERED,
+                GardenState.WATERED_RECENTLY
+        );
+
+        // 5. SharedPlant와 Friendship 짝짓기 및 위젯 상태 필터링
+        List<SharedPlantResDTO.SharedPlantInfoDTO> sharedPlantInfoDTOs = sharedPlants.stream()
+                .map(sp -> {
+                    Long friendId = sp.getMemberA().getId().equals(memberId)
+                            ? sp.getMemberB().getId()
+                            : sp.getMemberA().getId();
+                    return new SharedPlantWithFriendship(sp, friendshipMap.get(friendId));
+                })
+                .filter(pair -> pair.friendship() != null)
+                .map(pair -> {
+                    SharedPlant sp = pair.sharedPlant();
+                    GardenState gardenState = gardenStateCalculator.calculateState(sp);
+                    int percentage = gardenStateCalculator.calculatePercentage(sp);
+                    return SharedPlantConverter.toSharedPlantInfoDTO(
+                            sp, pair.friendship(), memberId, gardenState, percentage
+                    );
+                })
+                .filter(dto -> widgetStates.contains(dto.gardenState()))
                 .toList();
 
         return SharedPlantConverter.toSharedPlantInfoListDTO(sharedPlantInfoDTOs, member.getNutrientCount());


### PR DESCRIPTION
## #️⃣연관된 이슈

#101 

## 📝작업 내용

- 홈 위젯용 공유 식물 조회 API 구현
- GardenState 기준 `WATERABLE, WATERED_RECENTLY, WITHERED` 식물만 조회

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
