### PR TITLE
[fix] MySQL 컨테이너 타임존을 KST로 설정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,9 +10,11 @@ services:
       MYSQL_DATABASE: symtalk
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
     ports:
       - "3306:3306"
     volumes:


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->

## 📝작업 내용
 docker-compose.prod.yml 파일에서 MySQL 컨테이너 타임존을 KST로 설정
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
