### PR TITLE
fix: docker compose 배포 안정성 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,3 +82,23 @@ jobs:
             docker pull ${{ secrets.DOCKER_USERNAME }}/symtalk-be
             docker pull ${{ secrets.DOCKER_USERNAME }}/nginx
             docker compose -f docker-compose.prod.yml up -d
+
+            echo "Waiting for application health check..."
+            i=1
+            while [ "$i" -le 30 ]; do
+              if curl -fsS https://43.202.184.232.nip.io/health; then
+                echo "Application is healthy."
+                docker compose -f docker-compose.prod.yml ps
+                exit 0
+              fi
+
+              echo "Health check attempt $i failed. Retrying in 10 seconds..."
+              i=$((i + 1))
+              sleep 10
+            done
+
+            echo "Deployment health check failed."
+            docker compose -f docker-compose.prod.yml ps
+            docker logs symtalk-be --tail=200 || true
+            docker logs nginx --tail=200 || true
+            exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,9 +84,15 @@ jobs:
             docker compose -f docker-compose.prod.yml up -d
 
             echo "Waiting for application health check..."
+            HEALTH_URL='${{ secrets.BACKEND_HEALTH_URL }}'
+            if [ -z "$HEALTH_URL" ]; then
+              echo "BACKEND_HEALTH_URL secret is not set."
+              exit 1
+            fi
+
             i=1
             while [ "$i" -le 30 ]; do
-              if curl -fsS https://43.202.184.232.nip.io/health; then
+              if curl -fsS "$HEALTH_URL"; then
                 echo "Application is healthy."
                 docker compose -f docker-compose.prod.yml ps
                 exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:17-jre
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,12 @@ services:
       - mysql_data:/var/lib/mysql
     networks:
       - symtalk_net
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   redis:
     container_name: redis
@@ -33,22 +39,36 @@ services:
       - redis_data:/data
     networks:
       - symtalk_net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   application:
     container_name: symtalk-be
     image: ccjngwn/symtalk-be:latest
     ports:
       - "8080:8080"
-    restart: on-failure
+    restart: unless-stopped
     environment:
       - TZ=Asia/Seoul
     env_file:
       - .env.prod
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - symtalk_net
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
 
   nginx:
     container_name: nginx
@@ -61,10 +81,17 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot
     depends_on:
-      - application
+      application:
+        condition: service_healthy
     networks:
       - symtalk_net
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   certbot:
     container_name: certbot

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -77,7 +77,6 @@ services:
       - 80:80
       - 443:443
     volumes:
-      - /home/ubuntu/compose/nginx/conf.d:/etc/nginx/conf.d:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot
     depends_on:

--- a/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/ws/**",
 					"/ws",
+					"/health",
 					"/api/signup/**",
 					"/api/auth/login",
 					"/api/auth/refresh",


### PR DESCRIPTION
## #️⃣연관된 이슈

#123

## 📝작업 내용

Docker Compose 기반 운영 배포 안정성을 개선했습니다.

기존 배포는 `docker compose up -d` 실행 여부만으로 성공을 판단하고 있었기 때문에, 컨테이너가 떠도 애플리케이션이 DB/Redis를 실제로 사용할 수 있는지, nginx가 앱 컨테이너를 정상적으로 바라볼 수 있는지 확인하지 못했습니다.

이번 작업에서는 MySQL, Redis, 애플리케이션, nginx에 healthcheck를 추가하고, 의존 서비스가 healthy 상태가 된 뒤 다음 컨테이너가 시작되도록 조정했습니다. 또한 CD 배포 이후 `/health` 응답을 검증해서 실제 서버가 정상 응답하지 않으면 Actions job이 실패하도록 변경했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [x] 의존성 추가/삭제

- `docker-compose.prod.yml`
  - MySQL, Redis, 애플리케이션, nginx healthcheck 추가
  - `application`이 MySQL/Redis healthy 이후 시작되도록 `depends_on.condition` 적용
  - `nginx`가 application healthy 이후 시작되도록 조정
  - `application` restart 정책을 `unless-stopped`로 변경
  - nginx 서버 설정 bind mount 제거
- `.github/workflows/cd.yml`
  - `BACKEND_HEALTH_URL` secret 기반 배포 후 health check 추가
  - 검증 실패 시 compose 상태와 주요 컨테이너 로그 출력
  - health check 실패 시 CD job 실패 처리
- `SecurityConfig`
  - `/health` 엔드포인트 인증 제외
- `Dockerfile`
  - application healthcheck에서 사용할 `curl` 설치

## 📸스크린샷 

- GitHub Actions CD 재실행 성공 확인

## 💬리뷰 요구사항 

- 배포 후 health check 실패 시 Actions job이 실패하도록 처리한 부분을 중점적으로 확인해주세요.
- `depends_on.condition: service_healthy`와 각 컨테이너 healthcheck 설정이 운영 배포 흐름에 적절한지 확인해주세요.