### PR TITLE
[feat] 로그아웃 및 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/cotato/itda/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.cotato.itda.domain.auth.dto.LoginRequest;
 import com.cotato.itda.domain.auth.dto.Tokens;
 import com.cotato.itda.domain.auth.service.AuthService;
+import com.cotato.itda.domain.auth.service.LogoutService;
 import com.cotato.itda.domain.auth.service.TokenReissueService;
 import com.cotato.itda.global.common.response.ApiResponse;
 
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+	private final LogoutService logoutService;
 	private final TokenReissueService tokenReissueService;
 
 	@Operation(
@@ -66,9 +68,27 @@ public class AuthController {
 	@PostMapping("/refresh")
 	public ApiResponse<Tokens.AccessTokenOnly> refresh(
 		@Parameter(hidden = true)
-		@RequestAttribute(ATTR_REFRESH_CLAIMS) Claims refreshClaims
+		@RequestAttribute(ATTR_REFRESH_CLAIMS) Claims refreshClaims,
+		@Parameter(hidden = true)
+		@RequestAttribute(ATTR_REFRESH_TOKEN) String refreshToken
 	) {
-		Tokens.AccessTokenOnly response = tokenReissueService.reissue(refreshClaims);
+		Tokens.AccessTokenOnly response = tokenReissueService.reissue(refreshToken, refreshClaims);
 		return ApiResponse.success(response);
+	}
+
+	@Operation(
+		summary = "로그아웃",
+		description = "Refresh 토큰을 블랙리스트에 등록해 이후 재발급을 차단한다."
+	)
+	@SecurityRequirement(name = "RefreshToken")
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(
+		@Parameter(hidden = true)
+		@RequestAttribute(ATTR_REFRESH_CLAIMS) Claims refreshClaims,
+		@Parameter(hidden = true)
+		@RequestAttribute(ATTR_REFRESH_TOKEN) String refreshToken
+	) {
+		logoutService.logout(refreshToken, refreshClaims);
+		return ApiResponse.success(null);
 	}
 }

--- a/src/main/java/com/cotato/itda/domain/auth/repository/RefreshTokenBlacklistRepository.java
+++ b/src/main/java/com/cotato/itda/domain/auth/repository/RefreshTokenBlacklistRepository.java
@@ -1,0 +1,51 @@
+package com.cotato.itda.domain.auth.repository;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenBlacklistRepository {
+
+	private static final String KEY_PREFIX = "auth:refresh:blacklist:";
+	private static final String VALUE = "logout";
+
+	private final StringRedisTemplate redis;
+
+	public void save(String refreshToken, Instant expiresAt) {
+		Duration ttl = Duration.between(Instant.now(), expiresAt);
+		if (ttl.isZero() || ttl.isNegative()) {
+			return;
+		}
+
+		redis.opsForValue().set(toKey(refreshToken), VALUE, ttl);
+	}
+
+	public boolean exists(String refreshToken) {
+		Boolean exists = redis.hasKey(toKey(refreshToken));
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private String toKey(String refreshToken) {
+		return KEY_PREFIX + sha256(refreshToken);
+	}
+
+	private String sha256(String value) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hash);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", e);
+		}
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/auth/service/AuthService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import com.cotato.itda.domain.auth.dto.LoginRequest;
 import com.cotato.itda.domain.auth.dto.Tokens;
 import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
 import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.AuthErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
@@ -36,6 +37,9 @@ public class AuthService {
 		Member savedMember = memberRepository.findByPhoneNumber(phoneNumber)
 			.orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
 		log.info("전화번호로 Member 조회 성공");
+		if (savedMember.getStatus() != MemberStatus.ACTIVE) {
+			throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+		}
 
 		// 3. DB에서 조회한 유저의 해시 변환된 비밀번호와 비교
 		String inputPassword = request.password();

--- a/src/main/java/com/cotato/itda/domain/auth/service/AuthService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.cotato.itda.domain.auth.service;
 
+import java.time.OffsetDateTime;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.itda.domain.auth.dto.LoginRequest;
 import com.cotato.itda.domain.auth.dto.Tokens;
+import com.cotato.itda.domain.member.config.MemberWithdrawalProperties;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.entity.MemberStatus;
 import com.cotato.itda.domain.member.repository.MemberRepository;
@@ -24,7 +28,9 @@ public class AuthService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberWithdrawalProperties memberWithdrawalProperties;
 
+	@Transactional
 	public Tokens login(LoginRequest request) {
 		// 1. 전화번호 검증
 		log.info("입력받은 전화번호: {}", request.phoneNumber());
@@ -37,7 +43,8 @@ public class AuthService {
 		Member savedMember = memberRepository.findByPhoneNumber(phoneNumber)
 			.orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
 		log.info("전화번호로 Member 조회 성공");
-		if (savedMember.getStatus() != MemberStatus.ACTIVE) {
+		if (savedMember.getStatus() != MemberStatus.ACTIVE
+			&& savedMember.getStatus() != MemberStatus.WITHDRAWAL_PENDING) {
 			throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
 		}
 
@@ -49,6 +56,14 @@ public class AuthService {
 			throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
 		}
 		log.info("입력받은 비밀번호와 DB저장된 비밀번호 검증 통과");
+
+		if (savedMember.getStatus() == MemberStatus.WITHDRAWAL_PENDING) {
+			if (isWithdrawalGracePeriodExpired(savedMember)) {
+				throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+			}
+			savedMember.restore();
+			log.info("탈퇴 유예 기간 내 로그인으로 회원 복구 완료: memberId={}", savedMember.getId());
+		}
 
 		// 4. access token 생성
 		IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(savedMember.getId(), "ROLE_USER");
@@ -66,6 +81,16 @@ public class AuthService {
 				issuedRefreshToken.expiresAt()
 			)
 		);
+	}
+
+	private boolean isWithdrawalGracePeriodExpired(Member member) {
+		if (member.getWithdrawnAt() == null) {
+			return true;
+		}
+
+		OffsetDateTime expiresAt = member.getWithdrawnAt()
+			.plusDays(memberWithdrawalProperties.getGracePeriodDays());
+		return !OffsetDateTime.now().isBefore(expiresAt);
 	}
 
 	private String normalizePhone(String phoneNumber) {

--- a/src/main/java/com/cotato/itda/domain/auth/service/LogoutService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/LogoutService.java
@@ -1,0 +1,24 @@
+package com.cotato.itda.domain.auth.service;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.auth.repository.RefreshTokenBlacklistRepository;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+	private final RefreshTokenBlacklistRepository refreshTokenBlacklistRepository;
+
+	@Transactional
+	public void logout(String refreshToken, Claims refreshClaims) {
+		Instant expiresAt = refreshClaims.getExpiration().toInstant();
+		refreshTokenBlacklistRepository.save(refreshToken, expiresAt);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
@@ -4,6 +4,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.itda.domain.auth.dto.Tokens;
+import com.cotato.itda.domain.auth.repository.RefreshTokenBlacklistRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.JwtErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.token.IssuedToken;
@@ -18,11 +22,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class TokenReissueService {
 	private final JwtTokenProvider jwtTokenProvider;
-	// 만약 실제 회원 상태 검증이 필요하면 DB 확인
-	// private final MemberRepository memberRepository;
+	private final RefreshTokenBlacklistRepository refreshTokenBlacklistRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional(readOnly = true)
-	public Tokens.AccessTokenOnly reissue(Claims refreshClaims) {
+	public Tokens.AccessTokenOnly reissue(String refreshToken, Claims refreshClaims) {
+		if (refreshTokenBlacklistRepository.exists(refreshToken)) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
 
 		// sub에서 사용자 식별자(memberId) 추출
 		String subject = refreshClaims.getSubject();
@@ -39,9 +46,12 @@ public class TokenReissueService {
 			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
 		}
 		log.info("리프레시 토큰에서 추출한 memberId: {}", memberId);
-		// 만약 사용자 상태 검증할 시 사용( 탈퇴/정지/휴면 여부 확인 등)
-		// Member member = memberRepository.findById(memberId)
-		// 	.orElseThrow(()-> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new BusinessException(JwtErrorCode.INVALID_TOKEN));
+		if (member.getStatus() != MemberStatus.ACTIVE) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
 
 		// 새 Access Token 발급
 		IssuedToken issuedAccessToken = jwtTokenProvider.createAccessToken(memberId, "ROLE_USER");

--- a/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
@@ -28,7 +28,7 @@ public class TokenReissueService {
 	@Transactional(readOnly = true)
 	public Tokens.AccessTokenOnly reissue(String refreshToken, Claims refreshClaims) {
 		if (refreshTokenBlacklistRepository.exists(refreshToken)) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+			throw new BusinessException(JwtErrorCode.LOGGED_OUT_TOKEN);
 		}
 
 		// sub에서 사용자 식별자(memberId) 추출

--- a/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
+++ b/src/main/java/com/cotato/itda/domain/auth/service/TokenReissueService.java
@@ -11,6 +11,7 @@ import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.JwtErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.token.IssuedToken;
+import com.cotato.itda.global.security.jwt.token.JwtSubjectParser;
 import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
 
 import io.jsonwebtoken.Claims;
@@ -24,6 +25,7 @@ public class TokenReissueService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenBlacklistRepository refreshTokenBlacklistRepository;
 	private final MemberRepository memberRepository;
+	private final JwtSubjectParser jwtSubjectParser;
 
 	@Transactional(readOnly = true)
 	public Tokens.AccessTokenOnly reissue(String refreshToken, Claims refreshClaims) {
@@ -31,20 +33,7 @@ public class TokenReissueService {
 			throw new BusinessException(JwtErrorCode.LOGGED_OUT_TOKEN);
 		}
 
-		// sub에서 사용자 식별자(memberId) 추출
-		String subject = refreshClaims.getSubject();
-		if (subject == null || subject.isBlank()) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
-		log.info("리프레시 토큰에서 추출한 subject: {}", subject);
-		Long memberId;
-
-		// subject(String) -> memberId(Long) 파싱
-		try {
-			memberId = Long.parseLong(subject);
-		} catch (NumberFormatException e) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
+		Long memberId = jwtSubjectParser.parseMemberId(refreshClaims);
 		log.info("리프레시 토큰에서 추출한 memberId: {}", memberId);
 
 		Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/cotato/itda/domain/member/config/MemberWithdrawalProperties.java
+++ b/src/main/java/com/cotato/itda/domain/member/config/MemberWithdrawalProperties.java
@@ -1,0 +1,19 @@
+package com.cotato.itda.domain.member.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "member.withdrawal")
+public class MemberWithdrawalProperties {
+	private int gracePeriodDays = 7;
+	private String cleanupCron = "0 0 3 * * *";
+	private String anonymizedPhonePrefix = "WD";
+	private String anonymizedName = "탈퇴한 회원";
+	private String anonymizedPasswordHash = "WITHDRAWN";
+}

--- a/src/main/java/com/cotato/itda/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cotato/itda/domain/member/controller/MemberController.java
@@ -1,23 +1,33 @@
 package com.cotato.itda.domain.member.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cotato.itda.domain.member.dto.WithdrawRequest;
+import com.cotato.itda.domain.member.service.MemberService;
+import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/member")
 @Tag(name = "Member", description = "멤버(사용자) 서비스 API")
 public class MemberController {
+
+	private final MemberService memberService;
 
 	@SecurityRequirement(name = "AccessToken")
 	@GetMapping("/health")
@@ -29,4 +39,14 @@ public class MemberController {
 		return "멤버 서비스 정상 작동 중";
 	}
 
+	@SecurityRequirement(name = "AccessToken")
+	@DeleteMapping("/me")
+	@Operation(summary = "회원 탈퇴", description = "현재 로그인한 회원을 탈퇴 처리하고 refresh token 재사용을 차단합니다.")
+	public ApiResponse<Void> withdraw(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@RequestBody @Valid WithdrawRequest request
+	) {
+		memberService.withdraw(jwtPrincipal.memberId(), request);
+		return ApiResponse.success(null);
+	}
 }

--- a/src/main/java/com/cotato/itda/domain/member/dto/WithdrawRequest.java
+++ b/src/main/java/com/cotato/itda/domain/member/dto/WithdrawRequest.java
@@ -1,0 +1,11 @@
+package com.cotato.itda.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawRequest(
+	@Schema(description = "Refresh Token(JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	@NotBlank(message = "refreshToken은 필수입니다.")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/cotato/itda/domain/member/entity/Member.java
+++ b/src/main/java/com/cotato/itda/domain/member/entity/Member.java
@@ -117,6 +117,10 @@ public class Member extends BaseTimeEntity {
 		this.status = MemberStatus.ACTIVE;
 	}
 
+	public void withdraw() {
+		this.status = MemberStatus.WITHDRAWN;
+	}
+
     public void updateProfile(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }

--- a/src/main/java/com/cotato/itda/domain/member/entity/Member.java
+++ b/src/main/java/com/cotato/itda/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.cotato.itda.domain.member.entity;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 import com.cotato.itda.global.entity.BaseTimeEntity;
 import com.cotato.itda.global.error.constant.SignupErrorCode;
@@ -35,11 +36,13 @@ import lombok.*;
 )
 public class Member extends BaseTimeEntity {
 
+	public static final int PHONE_NUMBER_MAX_LENGTH = 15;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "phone_number", nullable = false, length = 15)
+	@Column(name = "phone_number", nullable = false, length = PHONE_NUMBER_MAX_LENGTH)
 	private String phoneNumber;
 
 	// YYYY-MM-DD
@@ -65,6 +68,9 @@ public class Member extends BaseTimeEntity {
 
 	@Column(name = "password_hash", nullable = false, length = 200)
 	private String passwordHash;
+
+	@Column(name = "withdrawn_at")
+	private OffsetDateTime withdrawnAt;
 
 	@Column(name = "nutrient_count", nullable = false)
 	@Builder.Default
@@ -118,7 +124,26 @@ public class Member extends BaseTimeEntity {
 	}
 
 	public void withdraw() {
+		this.status = MemberStatus.WITHDRAWAL_PENDING;
+		this.withdrawnAt = OffsetDateTime.now();
+	}
+
+	public void restore() {
+		this.status = MemberStatus.ACTIVE;
+		this.withdrawnAt = null;
+	}
+
+	public void finalizeWithdrawal(
+		String anonymizedPhoneNumber,
+		String anonymizedName,
+		String anonymizedPasswordHash
+	) {
 		this.status = MemberStatus.WITHDRAWN;
+		this.phoneNumber = anonymizedPhoneNumber;
+		this.name = anonymizedName;
+		this.passwordHash = anonymizedPasswordHash;
+		this.profileImageUrl = null;
+		this.inviteCode = null;
 	}
 
     public void updateProfile(String profileImageUrl) {

--- a/src/main/java/com/cotato/itda/domain/member/entity/MemberStatus.java
+++ b/src/main/java/com/cotato/itda/domain/member/entity/MemberStatus.java
@@ -1,5 +1,5 @@
 package com.cotato.itda.domain.member.entity;
 
 public enum MemberStatus {
-	ACTIVE, BLOCKED;
+	ACTIVE, BLOCKED, WITHDRAWN;
 }

--- a/src/main/java/com/cotato/itda/domain/member/entity/MemberStatus.java
+++ b/src/main/java/com/cotato/itda/domain/member/entity/MemberStatus.java
@@ -1,5 +1,5 @@
 package com.cotato.itda.domain.member.entity;
 
 public enum MemberStatus {
-	ACTIVE, BLOCKED, WITHDRAWN;
+	ACTIVE, BLOCKED, WITHDRAWN, WITHDRAWAL_PENDING;
 }

--- a/src/main/java/com/cotato/itda/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/cotato/itda/domain/member/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.cotato.itda.domain.member.repository;
 
+import java.util.List;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByPhoneNumber(String phoneNumber);
@@ -25,4 +28,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	void updatePasswordByPhoneNumber(String encodedPassword, String phoneNumber);
 
 	Optional<Member> findByInviteCode(String inviteCode);
+
+	List<Member> findAllByStatusAndWithdrawnAtBefore(MemberStatus status, OffsetDateTime withdrawnAt);
 }

--- a/src/main/java/com/cotato/itda/domain/member/scheduler/MemberWithdrawalCleanupScheduler.java
+++ b/src/main/java/com/cotato/itda/domain/member/scheduler/MemberWithdrawalCleanupScheduler.java
@@ -1,0 +1,56 @@
+package com.cotato.itda.domain.member.scheduler;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.member.config.MemberWithdrawalProperties;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberWithdrawalCleanupScheduler {
+
+	private final MemberRepository memberRepository;
+	private final MemberWithdrawalProperties memberWithdrawalProperties;
+
+	@Scheduled(cron = "${member.withdrawal.cleanup-cron}")
+	@Transactional
+	public void finalizeExpiredWithdrawals() {
+		OffsetDateTime cutoff = OffsetDateTime.now()
+			.minusDays(memberWithdrawalProperties.getGracePeriodDays());
+		List<Member> members = memberRepository.findAllByStatusAndWithdrawnAtBefore(
+			MemberStatus.WITHDRAWAL_PENDING,
+			cutoff
+		);
+
+		for (Member member : members) {
+			member.finalizeWithdrawal(
+				buildAnonymizedPhoneNumber(member),
+				memberWithdrawalProperties.getAnonymizedName(),
+				memberWithdrawalProperties.getAnonymizedPasswordHash()
+			);
+		}
+
+		if (!members.isEmpty()) {
+			log.info("탈퇴 유예 기간 만료 회원 최종 처리 완료: count={}", members.size());
+		}
+	}
+
+	private String buildAnonymizedPhoneNumber(Member member) {
+		String memberId = String.valueOf(member.getId());
+		String prefix = memberWithdrawalProperties.getAnonymizedPhonePrefix();
+		int prefixLength = Math.max(0, Member.PHONE_NUMBER_MAX_LENGTH - memberId.length());
+		String safePrefix = prefix.substring(0, Math.min(prefix.length(), prefixLength));
+		return safePrefix + memberId;
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/member/service/MemberService.java
+++ b/src/main/java/com/cotato/itda/domain/member/service/MemberService.java
@@ -1,0 +1,58 @@
+package com.cotato.itda.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.auth.service.LogoutService;
+import com.cotato.itda.domain.member.dto.WithdrawRequest;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.constant.UserErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final JwtTokenValidator jwtTokenValidator;
+	private final LogoutService logoutService;
+
+	@Transactional
+	public void withdraw(Long memberId, WithdrawRequest request) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+		if (member.getStatus() != MemberStatus.ACTIVE) {
+			throw new BusinessException(UserErrorCode.WITHDRAWN_USER);
+		}
+
+		Claims refreshClaims = jwtTokenValidator.validateAndGetClaims(request.refreshToken(), JwtPurpose.REFRESH);
+		Long refreshMemberId = parseMemberId(refreshClaims);
+		if (!memberId.equals(refreshMemberId)) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+
+		member.withdraw();
+		logoutService.logout(request.refreshToken(), refreshClaims);
+	}
+
+	private Long parseMemberId(Claims refreshClaims) {
+		String subject = refreshClaims.getSubject();
+		if (subject == null || subject.isBlank()) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+
+		try {
+			return Long.parseLong(subject);
+		} catch (NumberFormatException e) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/member/service/MemberService.java
+++ b/src/main/java/com/cotato/itda/domain/member/service/MemberService.java
@@ -12,6 +12,7 @@ import com.cotato.itda.global.error.constant.JwtErrorCode;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.token.JwtSubjectParser;
 import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
 
 import io.jsonwebtoken.Claims;
@@ -23,6 +24,7 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final JwtTokenValidator jwtTokenValidator;
+	private final JwtSubjectParser jwtSubjectParser;
 	private final LogoutService logoutService;
 
 	@Transactional
@@ -34,25 +36,12 @@ public class MemberService {
 		}
 
 		Claims refreshClaims = jwtTokenValidator.validateAndGetClaims(request.refreshToken(), JwtPurpose.REFRESH);
-		Long refreshMemberId = parseMemberId(refreshClaims);
+		Long refreshMemberId = jwtSubjectParser.parseMemberId(refreshClaims);
 		if (!memberId.equals(refreshMemberId)) {
 			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
 		}
 
 		member.withdraw();
 		logoutService.logout(request.refreshToken(), refreshClaims);
-	}
-
-	private Long parseMemberId(Claims refreshClaims) {
-		String subject = refreshClaims.getSubject();
-		if (subject == null || subject.isBlank()) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
-
-		try {
-			return Long.parseLong(subject);
-		} catch (NumberFormatException e) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
 	}
 }

--- a/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
 					"/api/signup/**",
 					"/api/auth/login",
 					"/api/auth/refresh",
+					"/api/auth/logout",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
 					"/api/password-reset/**"

--- a/src/main/java/com/cotato/itda/global/error/constant/JwtErrorCode.java
+++ b/src/main/java/com/cotato/itda/global/error/constant/JwtErrorCode.java
@@ -13,6 +13,7 @@ public enum JwtErrorCode implements ErrorCode {
 	// 401 Unauthorized: 인증 실패
 
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 입니다.", "JWT_401_INVALID"),
+	LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "이미 로그아웃 처리된 JWT 토큰입니다.", "JWT_401_LOGGED_OUT"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.", "JWT_401_EXPIRED"),
 	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다.", "JWT_401_UNSUPPORTED"),
 	MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 형식의 JWT 토큰입니다.", "JWT_401_MALFORMED"),

--- a/src/main/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilter.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilter.java
@@ -8,8 +8,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.error.exception.JwtAuthenticationException;
 import com.cotato.itda.global.security.jwt.config.JwtPurpose;
 import com.cotato.itda.global.security.jwt.extractor.BearerTokenExtractor;
+import com.cotato.itda.global.security.jwt.handler.JwtAuthenticationEntryPoint;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
 import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
 
@@ -39,6 +46,8 @@ public class AccessTokenFilter extends OncePerRequestFilter {
 
 	private final JwtTokenValidator jwtTokenValidator;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberRepository memberRepository;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 	/**
 	 * Access 인증이 필요 없는 경로는 필터를 스킵한다.
@@ -86,16 +95,38 @@ public class AccessTokenFilter extends OncePerRequestFilter {
 		 *
 		 * 2) 검증 성공 시에만 Authentication 생성
 		 */
-		Claims claims = jwtTokenValidator.validateAndGetClaims(token, JwtPurpose.ACCESS);
+		try {
+			Claims claims = jwtTokenValidator.validateAndGetClaims(token, JwtPurpose.ACCESS);
 
-		/**
-		 *   JwtTokenProvider가 "Claims 기반 Authentication 생성" 오버로드를 제공하는 것.
-		 */
-		Authentication authentication = jwtTokenProvider.getAuthentication(claims);
+			/**
+			 *   JwtTokenProvider가 "Claims 기반 Authentication 생성" 오버로드를 제공하는 것.
+			 */
+			Authentication authentication = jwtTokenProvider.getAuthentication(claims);
+			validateActiveMember(authentication);
 
-		SecurityContextHolder.getContext().setAuthentication(authentication);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		filterChain.doFilter(request, response);
+			filterChain.doFilter(request, response);
+		} catch (BusinessException e) {
+			SecurityContextHolder.clearContext();
+			JwtErrorCode errorCode = e.getErrorCode() instanceof JwtErrorCode jwtErrorCode
+				? jwtErrorCode
+				: JwtErrorCode.INVALID_TOKEN;
+			jwtAuthenticationEntryPoint.commence(request, response, new JwtAuthenticationException(errorCode));
+		}
+	}
+
+	private void validateActiveMember(Authentication authentication) {
+		if (!(authentication.getPrincipal() instanceof JwtPrincipal principal)) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+
+		MemberStatus status = memberRepository.findById(principal.memberId())
+			.orElseThrow(() -> new BusinessException(JwtErrorCode.INVALID_TOKEN))
+			.getStatus();
+		if (status != MemberStatus.ACTIVE) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
 	}
 
 }

--- a/src/main/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilter.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilter.java
@@ -55,6 +55,8 @@ public class AccessTokenFilter extends OncePerRequestFilter {
 
 		if (uri.startsWith("/api/auth/refresh"))
 			return true;
+		if (uri.startsWith("/api/auth/logout"))
+			return true;
 		if (uri.startsWith("/api/onboarding"))
 			return true;
 

--- a/src/main/java/com/cotato/itda/global/security/jwt/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/filter/RefreshTokenFilter.java
@@ -7,6 +7,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.error.exception.JwtAuthenticationException;
 import com.cotato.itda.global.security.jwt.config.JwtPurpose;
 import com.cotato.itda.global.security.jwt.extractor.BearerTokenExtractor;
@@ -39,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 public class RefreshTokenFilter extends OncePerRequestFilter {
 
 	public static final String ATTR_REFRESH_CLAIMS = "REFRESH_CLAIMS";
+	public static final String ATTR_REFRESH_TOKEN = "REFRESH_TOKEN";
 
 	private final JwtTokenValidator jwtTokenValidator;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -47,8 +50,8 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String uri = request.getRequestURI();
 
-		// refresh 엔드포인트에서만 필터 동작
-		return !uri.startsWith("/api/auth/refresh");
+		// refresh token 검증이 필요한 인증 엔드포인트에서만 필터 동작
+		return !uri.startsWith("/api/auth/refresh") && !uri.startsWith("/api/auth/logout");
 	}
 
 	@Override
@@ -67,6 +70,7 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
 			// 목적/alg/만료/서명/형식 검증 + Claims 반환
 			Claims claims = jwtTokenValidator.validateAndGetClaims(refreshToken, JwtPurpose.REFRESH);
 
+			request.setAttribute(ATTR_REFRESH_TOKEN, refreshToken);
 			request.setAttribute(ATTR_REFRESH_CLAIMS, claims);
 
 			filterChain.doFilter(request, response);
@@ -74,7 +78,13 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
 			SecurityContextHolder.clearContext();
 			jwtAuthenticationEntryPoint.commence(request, response, e);
 			return;
+		} catch (BusinessException e) {
+			SecurityContextHolder.clearContext();
+			JwtErrorCode errorCode = e.getErrorCode() instanceof JwtErrorCode jwtErrorCode
+				? jwtErrorCode
+				: JwtErrorCode.INVALID_TOKEN;
+			jwtAuthenticationEntryPoint.commence(request, response, new JwtAuthenticationException(errorCode));
+			return;
 		}
 	}
 }
-

--- a/src/main/java/com/cotato/itda/global/security/jwt/token/JwtSubjectParser.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/token/JwtSubjectParser.java
@@ -1,0 +1,29 @@
+package com.cotato.itda.global.security.jwt.token;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+import io.jsonwebtoken.Claims;
+
+@Component
+public class JwtSubjectParser {
+
+	public Long parseMemberId(Claims claims) {
+		Objects.requireNonNull(claims, "claims must not be null");
+
+		String subject = claims.getSubject();
+		if (subject == null || subject.isBlank()) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+
+		try {
+			return Long.parseLong(subject);
+		} catch (NumberFormatException e) {
+			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/cotato/itda/global/security/jwt/token/JwtTokenProvider.java
+++ b/src/main/java/com/cotato/itda/global/security/jwt/token/JwtTokenProvider.java
@@ -43,6 +43,7 @@ public class JwtTokenProvider {
 	private static final String CLAIM_PURPOSE = "purpose";
 	private final JwtProperties jwtProperties;
 	private final JwtKeyProvider jwtKeyProvider;
+	private final JwtSubjectParser jwtSubjectParser;
 
 	public IssuedToken createAccessToken(Long memberId, String role) {
 		return createToken(
@@ -121,36 +122,15 @@ public class JwtTokenProvider {
 		// 객체가 null이면 안됨
 		Objects.requireNonNull(claims, "claims must not be null");
 		log.info("JwtTokenProvider.getAuthentication called with claims: {}", claims);
-		/**
-		 * 1) 사용자 식별자 확보
-		 * - 최소한 subject는 있어야 인증된 사용자로 의미가 성립된다.
-		 * - subject가 없으면 토큰 구조/발급 정책 위반으로 간주한다.
-		 */
-		String subject = claims.getSubject();
-		if (subject == null || subject.isBlank()) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
-
-		/**
-		 * 2) 목적 클레임이 ACCESS가 아니면 예외
-		 */
+		// ACCESS 목적 클레임이 아니면 예외
 		String purpose = claims.get(CLAIM_PURPOSE, String.class);
 		if (!JwtPurpose.ACCESS.name().equals(purpose)) {
 			throw new BusinessException(JwtErrorCode.TOKEN_PURPOSE_MISMATCH);
 		}
 
-		/**
-		 * 3) sub = memberId이므로 String(subject) -> Long(memberId) 파싱
-		 * 만약 sub을 memberId로 안두고 따로 둔다면 건너뛰기
-		 */
-		Long memberId;
-		try {
-			memberId = Long.parseLong(subject);
-		} catch (NumberFormatException e) {
-			throw new BusinessException(JwtErrorCode.INVALID_TOKEN);
-		}
+		Long memberId = jwtSubjectParser.parseMemberId(claims);
 
-		JwtPrincipal principal = new JwtPrincipal(memberId, subject, "ACCESS");
+		JwtPrincipal principal = new JwtPrincipal(memberId, claims.getSubject(), "ACCESS");
 
 		/**
 		 * 권한(Authorities) 구성

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -61,6 +61,14 @@ signup:
 password-reset:
   draft-ttl-minutes: 60
 
+member:
+  withdrawal:
+    grace-period-days: ${MEMBER_WITHDRAWAL_GRACE_PERIOD_DAYS:7}
+    cleanup-cron: ${MEMBER_WITHDRAWAL_CLEANUP_CRON:0 0 3 * * *}
+    anonymized-phone-prefix: ${MEMBER_WITHDRAWAL_ANONYMIZED_PHONE_PREFIX:WD}
+    anonymized-name: ${MEMBER_WITHDRAWAL_ANONYMIZED_NAME:탈퇴한 회원}
+    anonymized-password-hash: ${MEMBER_WITHDRAWAL_ANONYMIZED_PASSWORD_HASH:WITHDRAWN}
+
 jwt:
   access:
     algorithm: HS256

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -84,6 +84,14 @@ signup:
 password-reset:
   draft-ttl-minutes: 60
 
+member:
+  withdrawal:
+    grace-period-days: ${MEMBER_WITHDRAWAL_GRACE_PERIOD_DAYS:7}
+    cleanup-cron: ${MEMBER_WITHDRAWAL_CLEANUP_CRON:0 0 3 * * *}
+    anonymized-phone-prefix: ${MEMBER_WITHDRAWAL_ANONYMIZED_PHONE_PREFIX:WD}
+    anonymized-name: ${MEMBER_WITHDRAWAL_ANONYMIZED_NAME:탈퇴한 회원}
+    anonymized-password-hash: ${MEMBER_WITHDRAWAL_ANONYMIZED_PASSWORD_HASH:WITHDRAWN}
+
 gemini:
   base-url: https://generativelanguage.googleapis.com
   model: gemini-2.5-flash-lite

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,11 @@ logging:
 
 signup:
   draft-ttl-minutes: 10
+
+member:
+  withdrawal:
+    grace-period-days: ${MEMBER_WITHDRAWAL_GRACE_PERIOD_DAYS:7}
+    cleanup-cron: ${MEMBER_WITHDRAWAL_CLEANUP_CRON:0 0 3 * * *}
+    anonymized-phone-prefix: ${MEMBER_WITHDRAWAL_ANONYMIZED_PHONE_PREFIX:WD}
+    anonymized-name: ${MEMBER_WITHDRAWAL_ANONYMIZED_NAME:탈퇴한 회원}
+    anonymized-password-hash: ${MEMBER_WITHDRAWAL_ANONYMIZED_PASSWORD_HASH:WITHDRAWN}

--- a/src/test/java/com/cotato/itda/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,60 @@
+package com.cotato.itda.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.cotato.itda.domain.auth.dto.LoginRequest;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.AuthErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Test
+	void login_rejects_withdrawn_member() {
+		LoginRequest request = new LoginRequest("01012345678", "password");
+		Member member = Member.builder()
+			.id(1L)
+			.phoneNumber("01012345678")
+			.status(MemberStatus.WITHDRAWN)
+			.passwordHash("encoded-password")
+			.build();
+
+		when(memberRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(member));
+
+		assertThatThrownBy(() -> authService.login(request))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+
+		verify(passwordEncoder, never()).matches("password", "encoded-password");
+		verify(jwtTokenProvider, never()).createAccessToken(1L, "ROLE_USER");
+	}
+}

--- a/src/test/java/com/cotato/itda/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/AuthServiceTest.java
@@ -1,10 +1,12 @@
 package com.cotato.itda.domain.auth.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -15,11 +17,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.cotato.itda.domain.auth.dto.LoginRequest;
+import com.cotato.itda.domain.auth.dto.Tokens;
+import com.cotato.itda.domain.member.config.MemberWithdrawalProperties;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.entity.MemberStatus;
 import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.AuthErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.token.IssuedAccessToken;
+import com.cotato.itda.global.security.jwt.token.IssuedRefreshToken;
 import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +39,9 @@ class AuthServiceTest {
 
 	@Mock
 	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private MemberWithdrawalProperties memberWithdrawalProperties;
 
 	@InjectMocks
 	private AuthService authService;
@@ -55,6 +64,59 @@ class AuthServiceTest {
 			.isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
 
 		verify(passwordEncoder, never()).matches("password", "encoded-password");
+		verify(jwtTokenProvider, never()).createAccessToken(1L, "ROLE_USER");
+	}
+
+	@Test
+	void login_restores_withdrawal_pending_member_within_grace_period() {
+		LoginRequest request = new LoginRequest("01012345678", "password");
+		Member member = Member.builder()
+			.id(1L)
+			.phoneNumber("01012345678")
+			.status(MemberStatus.WITHDRAWAL_PENDING)
+			.withdrawnAt(OffsetDateTime.now().minusDays(3))
+			.passwordHash("encoded-password")
+			.build();
+		OffsetDateTime accessExpiresAt = OffsetDateTime.now().plusHours(1);
+		OffsetDateTime refreshExpiresAt = OffsetDateTime.now().plusDays(14);
+
+		when(memberRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(member));
+		when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+		when(memberWithdrawalProperties.getGracePeriodDays()).thenReturn(7);
+		when(jwtTokenProvider.createAccessToken(1L, "ROLE_USER"))
+			.thenReturn(new IssuedAccessToken("access-token", accessExpiresAt));
+		when(jwtTokenProvider.createRefreshToken(1L))
+			.thenReturn(new IssuedRefreshToken("refresh-token", refreshExpiresAt));
+
+		Tokens tokens = authService.login(request);
+
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.getWithdrawnAt()).isNull();
+		assertThat(tokens.accessToken().accessToken()).isEqualTo("access-token");
+		assertThat(tokens.refreshToken().refreshToken()).isEqualTo("refresh-token");
+	}
+
+	@Test
+	void login_rejects_withdrawal_pending_member_after_grace_period() {
+		LoginRequest request = new LoginRequest("01012345678", "password");
+		Member member = Member.builder()
+			.id(1L)
+			.phoneNumber("01012345678")
+			.status(MemberStatus.WITHDRAWAL_PENDING)
+			.withdrawnAt(OffsetDateTime.now().minusDays(8))
+			.passwordHash("encoded-password")
+			.build();
+
+		when(memberRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(member));
+		when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+		when(memberWithdrawalProperties.getGracePeriodDays()).thenReturn(7);
+
+		assertThatThrownBy(() -> authService.login(request))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWAL_PENDING);
 		verify(jwtTokenProvider, never()).createAccessToken(1L, "ROLE_USER");
 	}
 }

--- a/src/test/java/com/cotato/itda/domain/auth/service/LogoutServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/LogoutServiceTest.java
@@ -1,0 +1,45 @@
+package com.cotato.itda.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.itda.domain.auth.repository.RefreshTokenBlacklistRepository;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+
+	@Mock
+	private RefreshTokenBlacklistRepository refreshTokenBlacklistRepository;
+
+	@InjectMocks
+	private LogoutService logoutService;
+
+	@Test
+	void logout_saves_refresh_token_to_blacklist_until_expiration() {
+		String refreshToken = "refresh-token";
+		Date expiration = Date.from(Instant.now().plusSeconds(3600));
+		Claims claims = Jwts.claims()
+			.expiration(expiration)
+			.build();
+
+		logoutService.logout(refreshToken, claims);
+
+		ArgumentCaptor<Instant> expiresAtCaptor = ArgumentCaptor.forClass(Instant.class);
+		verify(refreshTokenBlacklistRepository).save(eq(refreshToken), expiresAtCaptor.capture());
+		assertThat(expiresAtCaptor.getValue()).isEqualTo(claims.getExpiration().toInstant());
+	}
+}

--- a/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
@@ -1,0 +1,109 @@
+package com.cotato.itda.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.itda.domain.auth.dto.Tokens;
+import com.cotato.itda.domain.auth.repository.RefreshTokenBlacklistRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.token.IssuedAccessToken;
+import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+class TokenReissueServiceTest {
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private RefreshTokenBlacklistRepository refreshTokenBlacklistRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private TokenReissueService tokenReissueService;
+
+	@Test
+	void reissue_rejects_blacklisted_refresh_token() {
+		String refreshToken = "refresh-token";
+		Claims claims = claims("1");
+		when(refreshTokenBlacklistRepository.exists(refreshToken)).thenReturn(true);
+
+		assertThatThrownBy(() -> tokenReissueService.reissue(refreshToken, claims))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(JwtErrorCode.INVALID_TOKEN);
+
+		verify(memberRepository, never()).findById(1L);
+		verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());
+	}
+
+	@Test
+	void reissue_issues_access_token_for_active_member() {
+		String refreshToken = "refresh-token";
+		Claims claims = claims("1");
+		OffsetDateTime expiresAt = OffsetDateTime.now().plusHours(1);
+		Member member = Member.builder()
+			.id(1L)
+			.status(MemberStatus.ACTIVE)
+			.build();
+
+		when(refreshTokenBlacklistRepository.exists(refreshToken)).thenReturn(false);
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		when(jwtTokenProvider.createAccessToken(1L, "ROLE_USER"))
+			.thenReturn(new IssuedAccessToken("new-access-token", expiresAt));
+
+		Tokens.AccessTokenOnly response = tokenReissueService.reissue(refreshToken, claims);
+
+		assertThat(response.accessToken()).isEqualTo("new-access-token");
+		assertThat(response.accessTokenExpiresAt()).isEqualTo(expiresAt);
+	}
+
+	@Test
+	void reissue_rejects_withdrawn_member() {
+		String refreshToken = "refresh-token";
+		Claims claims = claims("1");
+		Member member = Member.builder()
+			.id(1L)
+			.status(MemberStatus.WITHDRAWN)
+			.build();
+
+		when(refreshTokenBlacklistRepository.exists(refreshToken)).thenReturn(false);
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+		assertThatThrownBy(() -> tokenReissueService.reissue(refreshToken, claims))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(JwtErrorCode.INVALID_TOKEN);
+
+		verify(jwtTokenProvider, never()).createAccessToken(1L, "ROLE_USER");
+	}
+
+	private Claims claims(String subject) {
+		return Jwts.claims()
+			.subject(subject)
+			.build();
+	}
+}

--- a/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
@@ -54,7 +54,7 @@ class TokenReissueServiceTest {
 		assertThatThrownBy(() -> tokenReissueService.reissue(refreshToken, claims))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
-			.isEqualTo(JwtErrorCode.INVALID_TOKEN);
+			.isEqualTo(JwtErrorCode.LOGGED_OUT_TOKEN);
 
 		verify(memberRepository, never()).findById(1L);
 		verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());

--- a/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/auth/service/TokenReissueServiceTest.java
@@ -25,6 +25,7 @@ import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.JwtErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.token.IssuedAccessToken;
+import com.cotato.itda.global.security.jwt.token.JwtSubjectParser;
 import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
 
 import io.jsonwebtoken.Claims;
@@ -41,6 +42,9 @@ class TokenReissueServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private JwtSubjectParser jwtSubjectParser;
 
 	@InjectMocks
 	private TokenReissueService tokenReissueService;
@@ -71,6 +75,7 @@ class TokenReissueServiceTest {
 			.build();
 
 		when(refreshTokenBlacklistRepository.exists(refreshToken)).thenReturn(false);
+		when(jwtSubjectParser.parseMemberId(claims)).thenReturn(1L);
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 		when(jwtTokenProvider.createAccessToken(1L, "ROLE_USER"))
 			.thenReturn(new IssuedAccessToken("new-access-token", expiresAt));
@@ -91,6 +96,7 @@ class TokenReissueServiceTest {
 			.build();
 
 		when(refreshTokenBlacklistRepository.exists(refreshToken)).thenReturn(false);
+		when(jwtSubjectParser.parseMemberId(claims)).thenReturn(1L);
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 
 		assertThatThrownBy(() -> tokenReissueService.reissue(refreshToken, claims))

--- a/src/test/java/com/cotato/itda/domain/member/scheduler/MemberWithdrawalCleanupSchedulerTest.java
+++ b/src/test/java/com/cotato/itda/domain/member/scheduler/MemberWithdrawalCleanupSchedulerTest.java
@@ -1,0 +1,67 @@
+package com.cotato.itda.domain.member.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.itda.domain.member.config.MemberWithdrawalProperties;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberWithdrawalCleanupSchedulerTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private MemberWithdrawalProperties memberWithdrawalProperties;
+
+	@InjectMocks
+	private MemberWithdrawalCleanupScheduler scheduler;
+
+	@Test
+	void finalizeExpiredWithdrawals_anonymizes_members_and_marks_withdrawn() {
+		Member member = Member.builder()
+			.id(1L)
+			.phoneNumber("01012345678")
+			.name("홍길동")
+			.status(MemberStatus.WITHDRAWAL_PENDING)
+			.passwordHash("encoded-password")
+			.profileImageUrl("https://example.com/profile.png")
+			.inviteCode("ABC123")
+			.withdrawnAt(OffsetDateTime.now().minusDays(8))
+			.build();
+		ArgumentCaptor<OffsetDateTime> cutoffCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+
+		when(memberWithdrawalProperties.getGracePeriodDays()).thenReturn(7);
+		when(memberWithdrawalProperties.getAnonymizedPhonePrefix()).thenReturn("WD");
+		when(memberWithdrawalProperties.getAnonymizedName()).thenReturn("탈퇴한 회원");
+		when(memberWithdrawalProperties.getAnonymizedPasswordHash()).thenReturn("WITHDRAWN");
+		when(memberRepository.findAllByStatusAndWithdrawnAtBefore(
+			eq(MemberStatus.WITHDRAWAL_PENDING),
+			cutoffCaptor.capture()
+		)).thenReturn(List.of(member));
+
+		scheduler.finalizeExpiredWithdrawals();
+
+		assertThat(cutoffCaptor.getValue()).isBeforeOrEqualTo(OffsetDateTime.now().minusDays(7).plusSeconds(1));
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWN);
+		assertThat(member.getPhoneNumber()).isEqualTo("WD1");
+		assertThat(member.getName()).isEqualTo("탈퇴한 회원");
+		assertThat(member.getPasswordHash()).isEqualTo("WITHDRAWN");
+		assertThat(member.getProfileImageUrl()).isNull();
+		assertThat(member.getInviteCode()).isNull();
+	}
+}

--- a/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,91 @@
+package com.cotato.itda.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.itda.domain.auth.service.LogoutService;
+import com.cotato.itda.domain.member.dto.WithdrawRequest;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private JwtTokenValidator jwtTokenValidator;
+
+	@Mock
+	private LogoutService logoutService;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@Test
+	void withdraw_marks_member_as_withdrawn_and_blacklists_refresh_token() {
+		String refreshToken = "refresh-token";
+		WithdrawRequest request = new WithdrawRequest(refreshToken);
+		Member member = Member.builder()
+			.id(1L)
+			.status(MemberStatus.ACTIVE)
+			.build();
+		Claims claims = claims("1");
+
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		when(jwtTokenValidator.validateAndGetClaims(refreshToken, JwtPurpose.REFRESH)).thenReturn(claims);
+
+		memberService.withdraw(1L, request);
+
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWN);
+		verify(logoutService).logout(refreshToken, claims);
+	}
+
+	@Test
+	void withdraw_rejects_refresh_token_of_another_member() {
+		String refreshToken = "refresh-token";
+		WithdrawRequest request = new WithdrawRequest(refreshToken);
+		Member member = Member.builder()
+			.id(1L)
+			.status(MemberStatus.ACTIVE)
+			.build();
+		Claims claims = claims("2");
+
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		when(jwtTokenValidator.validateAndGetClaims(refreshToken, JwtPurpose.REFRESH)).thenReturn(claims);
+
+		assertThatThrownBy(() -> memberService.withdraw(1L, request))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(JwtErrorCode.INVALID_TOKEN);
+
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		verify(logoutService, never()).logout(refreshToken, claims);
+	}
+
+	private Claims claims(String subject) {
+		return Jwts.claims()
+			.subject(subject)
+			.build();
+	}
+}

--- a/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
@@ -47,7 +47,7 @@ class MemberServiceTest {
 	private MemberService memberService;
 
 	@Test
-	void withdraw_marks_member_as_withdrawn_and_blacklists_refresh_token() {
+	void withdraw_marks_member_as_withdrawal_pending_and_blacklists_refresh_token() {
 		String refreshToken = "refresh-token";
 		WithdrawRequest request = new WithdrawRequest(refreshToken);
 		Member member = Member.builder()
@@ -62,7 +62,8 @@ class MemberServiceTest {
 
 		memberService.withdraw(1L, request);
 
-		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWN);
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWAL_PENDING);
+		assertThat(member.getWithdrawnAt()).isNotNull();
 		verify(logoutService).logout(refreshToken, claims);
 	}
 

--- a/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/member/service/MemberServiceTest.java
@@ -22,6 +22,7 @@ import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.JwtErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.token.JwtSubjectParser;
 import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
 
 import io.jsonwebtoken.Claims;
@@ -35,6 +36,9 @@ class MemberServiceTest {
 
 	@Mock
 	private JwtTokenValidator jwtTokenValidator;
+
+	@Mock
+	private JwtSubjectParser jwtSubjectParser;
 
 	@Mock
 	private LogoutService logoutService;
@@ -54,6 +58,7 @@ class MemberServiceTest {
 
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 		when(jwtTokenValidator.validateAndGetClaims(refreshToken, JwtPurpose.REFRESH)).thenReturn(claims);
+		when(jwtSubjectParser.parseMemberId(claims)).thenReturn(1L);
 
 		memberService.withdraw(1L, request);
 
@@ -73,6 +78,7 @@ class MemberServiceTest {
 
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 		when(jwtTokenValidator.validateAndGetClaims(refreshToken, JwtPurpose.REFRESH)).thenReturn(claims);
+		when(jwtSubjectParser.parseMemberId(claims)).thenReturn(2L);
 
 		assertThatThrownBy(() -> memberService.withdraw(1L, request))
 			.isInstanceOf(BusinessException.class)

--- a/src/test/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilterTest.java
+++ b/src/test/java/com/cotato/itda/global/security/jwt/filter/AccessTokenFilterTest.java
@@ -1,0 +1,87 @@
+package com.cotato.itda.global.security.jwt.filter;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.entity.MemberStatus;
+import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.global.error.constant.JwtErrorCode;
+import com.cotato.itda.global.error.exception.JwtAuthenticationException;
+import com.cotato.itda.global.security.jwt.config.JwtPurpose;
+import com.cotato.itda.global.security.jwt.handler.JwtAuthenticationEntryPoint;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+import com.cotato.itda.global.security.jwt.token.JwtTokenProvider;
+import com.cotato.itda.global.security.jwt.token.JwtTokenValidator;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.FilterChain;
+
+@ExtendWith(MockitoExtension.class)
+class AccessTokenFilterTest {
+
+	@Mock
+	private JwtTokenValidator jwtTokenValidator;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Mock
+	private FilterChain filterChain;
+
+	@InjectMocks
+	private AccessTokenFilter accessTokenFilter;
+
+	@Test
+	void doFilterInternal_rejects_access_token_when_member_is_not_active() throws Exception {
+		String accessToken = "access-token";
+		Claims claims = Jwts.claims()
+			.subject("1")
+			.build();
+		JwtPrincipal principal = new JwtPrincipal(1L, "1", "ACCESS");
+		Member member = Member.builder()
+			.id(1L)
+			.status(MemberStatus.WITHDRAWAL_PENDING)
+			.build();
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/member/health");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+		when(jwtTokenValidator.validateAndGetClaims(accessToken, JwtPurpose.ACCESS)).thenReturn(claims);
+		when(jwtTokenProvider.getAuthentication(claims))
+			.thenReturn(new UsernamePasswordAuthenticationToken(principal, null));
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+		accessTokenFilter.doFilterInternal(request, response, filterChain);
+
+		verify(filterChain, never()).doFilter(request, response);
+		verify(jwtAuthenticationEntryPoint).commence(
+			org.mockito.ArgumentMatchers.eq(request),
+			org.mockito.ArgumentMatchers.eq(response),
+			org.mockito.ArgumentMatchers.argThat(exception ->
+				exception instanceof JwtAuthenticationException jwtException
+					&& jwtException.getErrorCode() == JwtErrorCode.INVALID_TOKEN
+			)
+		);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #125

## 📝작업 내용

- refresh token 블랙리스트 기반 로그아웃 API를 구현했습니다.
- 회원 탈퇴를 7일 유예 기간이 있는 소프트 탈퇴 방식으로 구현했습니다.
- 탈퇴 유예 기간 내 재로그인 시 계정을 복구하고, 유예 기간 만료 후에는 스케줄러가 개인정보를 마스킹한 뒤 최종 탈퇴 처리합니다.
- 탈퇴/로그아웃된 refresh token 재사용과 탈퇴 회원의 토큰 재발급을 차단하도록 인증 로직을 보강했습니다.
- 보호 API access token 인증 시 회원 상태를 확인해 `ACTIVE` 회원만 접근할 수 있도록 보강했습니다.

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

- 없음

## 📌참고 사항

- `POST /api/auth/logout`는 refresh token을 Redis 블랙리스트에 등록합니다. TTL은 고정값이 아니라 해당 refresh token의 남은 만료 시간입니다.
- `DELETE /api/member/me`는 access token으로 본인을 식별하고, 요청 바디의 refresh token이 같은 회원의 토큰인지 확인한 뒤 블랙리스트에 등록합니다.
- 회원 탈퇴 요청 시 `WITHDRAWAL_PENDING`, `withdrawnAt`으로 전환하고, 7일 안에 로그인하면 `ACTIVE`로 복구합니다.
- 유예 기간이 지난 탈퇴 대기 회원은 스케줄러가 전화번호/이름/비밀번호/프로필/초대코드를 마스킹하고 `WITHDRAWN`으로 전환합니다.
- 유예 기간, cleanup cron, 마스킹 값은 `member.withdrawal.*` 설정으로 분리했습니다.
- 운영 DB는 `ddl-auto: none`이므로 배포 전 아래 컬럼 수동 추가가 필요합니다.

```sql
ALTER TABLE members ADD COLUMN withdrawn_at datetime(6) NULL;
```

- access token 상태 검증을 위해 보호 API 요청마다 회원 상태 DB 조회가 추가됩니다.

## 💬리뷰 요구사항 

- 회원 탈퇴 유예 기간 내 로그인 복구 정책과 유예 기간 만료 후 마스킹 처리 흐름이 서비스 정책에 맞는지 확인 부탁드립니다.
- access token 인증 시 회원 상태를 매번 조회하도록 한 방식이 현재 트래픽/운영 기준에서 괜찮은지 확인 부탁드립니다.