### PR TITLE
[fix] WebSocket nginx 프록시 설정 복구

### DIFF
--- a/nginx/conf.d/nginx.conf
+++ b/nginx/conf.d/nginx.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # HTTP 요청을 HTTPS로 리다이렉트
 server {
     listen 80;
@@ -21,6 +26,25 @@ server {
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location ^~ /ws {
+        proxy_pass http://symtalk-be:8080;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
 
     location / {
         proxy_pass http://symtalk-be:8080;


### PR DESCRIPTION
## #️⃣연관된 이슈

#127

## 📝작업 내용

WebSocket 연결을 위한 nginx 프록시 설정을 복구했습니다.

기존에는 EC2의 nginx 설정 파일에 `/ws` 전용 WebSocket 프록시 설정이 있었지만, nginx 설정을 이미지에 포함해 배포하는 방식으로 변경되면서 EC2 설정 파일은 더 이상 컨테이너에 mount되지 않았습니다.

이후 실제 운영 nginx 컨테이너는 리포의 `nginx/conf.d/nginx.conf`를 기준으로 빌드된 이미지 설정을 사용하게 되었고, 해당 설정에는 WebSocket Upgrade 헤더 전달 설정이 없어 `/ws` 연결 시 handshake가 실패할 수 있었습니다.

이번 작업에서는 리포의 nginx 설정에 `/ws` 전용 location을 추가하고, WebSocket Upgrade/Connection 헤더를 백엔드 애플리케이션 컨테이너로 전달하도록 수정했습니다. 또한 WebSocket 장시간 연결을 위해 read/send timeout을 3600초로 설정하고 proxy buffering을 비활성화했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

`nginx/conf.d/nginx.conf`

- `/ws` 전용 WebSocket 프록시 location 추가
- `proxy_http_version 1.1` 설정 추가
- `Upgrade`, `Connection` 헤더가 백엔드로 전달되도록 설정
- WebSocket 연결 유지를 위해 `proxy_read_timeout`, `proxy_send_timeout`을 3600초로 설정
- WebSocket 응답 buffering 비활성화
- `map $http_upgrade $connection_upgrade` 설정 추가로 Upgrade 요청 여부에 따라 Connection 헤더 값을 분기

## 📸스크린샷 

- EC2의 실제 compose 네트워크와 인증서 볼륨 조건에서 `nginx -t` 성공 확인
- GitHub Actions CI 성공 확인

## 💬리뷰 요구사항 

- `/ws` location이 기존 HTTP API 프록시 설정과 충돌하지 않는지 확인해주세요.
- WebSocket Upgrade/Connection 헤더 설정이 운영 nginx 이미지 기준으로 적절한지 확인해주세요.
- WebSocket timeout을 3600초로 설정한 부분이 현재 서비스 사용 흐름에 적절한지 확인해주세요.
