### PR TITLE
[fix] 채팅방 재입장 시 상대방 정보 누락 수정 및 나가기 시 히스토리 초기화 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/challenge/controller/ChallengeCommentController.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/controller/ChallengeCommentController.java
@@ -27,11 +27,13 @@ public class ChallengeCommentController {
     private final ChallengeCommentQueryService challengeCommentQueryService;
 
     @Operation(
-            summary = "챌린지 댓글 등록 API",
+            summary = "챌린지 댓글/대댓글 등록 API",
             description = """
                     pathVariable로 전달받은 특정 챌린지에 댓글을 등록합니다. 
                     - 등록 후 댓글 정보와 작성자 정보가 반환됩니다.
                     - 본인 또는 친구의 챌린지에만 댓글을 등록할 수 있습니다.
+                    - 대댓글 작성 시, Request Body에 부모 댓글 ID(`parentId`)를 포함해야 합니다.
+                    - 대댓글에 다시 대댓글을 달 경우 400 에러가 발생합니다.
                     """
     )
     @ApiResponses({
@@ -56,11 +58,13 @@ public class ChallengeCommentController {
     }
 
     @Operation(
-            summary = "챌린지 댓글 삭제 API",
+            summary = "챌린지 댓글/대댓글 삭제 API",
             description = """
                     특정 댓글을 삭제합니다. 
                     - 작성자 본인만 삭제 가능합니다. 
                     - DB에서 완전히 삭제되지 않고, 삭제 상태로 변경되어 조회되지 않습니다.
+                    - 부모 댓글을 삭제한 경우, "삭제된 댓글입니다."로 마스킹 처리되어 반환됩니다.
+                    - 자식 댓글이 남아 있는 경우, 그대로 반환됩니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/com/cotato/itda/domain/challenge/converter/ChallengeCommentConverter.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/converter/ChallengeCommentConverter.java
@@ -50,21 +50,46 @@ public class ChallengeCommentConverter {
 
     public static ChallengeCommentListResponse.CommentItem toListItem(
             ChallengeComment comment,
-            ChallengeCommentListResponse.WriterInfo writerInfo
+            ChallengeCommentListResponse.WriterInfo writerInfo,
+            List<ChallengeCommentListResponse.CommentItem> childItems
     ) {
         return ChallengeCommentListResponse.CommentItem.builder()
                 .commentId(comment.getId())
                 .writerInfo(writerInfo)
                 .content(comment.getContent())
+                .childComments(childItems)
                 .createdAt(comment.getCreatedAt())
+                .isDeleted(false)
                 .build();
     }
 
     public static ChallengeCommentListResponse.WriterInfo toListWriterInfo(Member member, String nickname) {
+        if (member == null) {
+            return ChallengeCommentListResponse.WriterInfo.builder()
+                    .memberId(null)
+                    .nickname(nickname)
+                    .profileImageUrl(null)
+                    .build();
+        }
         return ChallengeCommentListResponse.WriterInfo.builder()
                 .memberId(member.getId())
                 .nickname(nickname)
                 .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+
+    public static ChallengeCommentListResponse.CommentItem toDeletedListItem(
+            ChallengeComment root,
+            ChallengeCommentListResponse.WriterInfo unknownWriter,
+            List<ChallengeCommentListResponse.CommentItem> childItems
+    ) {
+        return ChallengeCommentListResponse.CommentItem.builder()
+                .commentId(root.getId())
+                .writerInfo(unknownWriter)
+                .content("삭제된 댓글입니다.")
+                .childComments(childItems)
+                .createdAt(root.getCreatedAt())
+                .isDeleted(true)
                 .build();
     }
 }

--- a/src/main/java/com/cotato/itda/domain/challenge/dto/request/ChallengeCommentRequest.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/dto/request/ChallengeCommentRequest.java
@@ -9,6 +9,9 @@ public record ChallengeCommentRequest(
         @Schema(description = "댓글 내용", example = "재밌었겠다")
         @NotBlank(message = "댓글 내용은 필수입니다.")
         @Size(min = 1, max = 5000, message = "댓글 내용은 1자 이상 5000자 이하여야 합니다.")
-        String content
+        String content,
+
+        @Schema(description = "부모 댓글 ID", example = "1")
+        Long parentId
 ) {
 }

--- a/src/main/java/com/cotato/itda/domain/challenge/dto/response/ChallengeCommentListResponse.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/dto/response/ChallengeCommentListResponse.java
@@ -1,5 +1,6 @@
 package com.cotato.itda.domain.challenge.dto.response;
 
+import com.cotato.itda.domain.diary.dto.response.DiaryCommentListResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -36,7 +37,13 @@ public record ChallengeCommentListResponse(
             String content,
 
             @Schema(description = "작성 시간", example = "2026-01-10T10:00:00")
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+
+            @Schema(description = "대댓글 목록, 없을 경우 빈 배열이 반환됩니다.")
+            List<ChallengeCommentListResponse.CommentItem> childComments,
+
+            @Schema(description = "댓글 삭제 여부", example = "false")
+            boolean isDeleted
     ) {
     }
 

--- a/src/main/java/com/cotato/itda/domain/challenge/entity/ChallengeComment.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/entity/ChallengeComment.java
@@ -1,12 +1,16 @@
 package com.cotato.itda.domain.challenge.entity;
 
+import com.cotato.itda.domain.diary.entity.DiaryComment;
+import com.cotato.itda.domain.diary.exception.code.DiaryErrorCode;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.global.entity.BaseEntity;
+import com.cotato.itda.global.error.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -14,7 +18,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "challenge_comment")
-@SQLRestriction("is_deleted = false")
 public class ChallengeComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -35,17 +38,28 @@ public class ChallengeComment extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    // 추후 대댓글 기능 도입 시 사용
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "parent_id")
-//    private ChallengeComment parentComment;
-//
-//    @OneToMany(mappedBy = "parentComment")
-//    @Builder.Default
-//    private List<ChallengeComment> childComments = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private ChallengeComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment")
+    @Builder.Default
+    private List<ChallengeComment> childComments = new ArrayList<>();
 
     public void delete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void setParent(ChallengeComment parent) {
+        if (parent == null) {
+            return;
+        }
+        // depth 2 제한
+        if (parent.getParentComment() != null) {
+            throw new BusinessException(DiaryErrorCode.REPLY_DEPTH_LIMIT);
+        }
+        this.parentComment = parent;
+        parent.getChildComments().add(this);
     }
 }

--- a/src/main/java/com/cotato/itda/domain/challenge/repository/ChallengeCommentRepository.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/repository/ChallengeCommentRepository.java
@@ -2,6 +2,12 @@ package com.cotato.itda.domain.challenge.repository;
 
 import com.cotato.itda.domain.challenge.entity.ChallengeComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeCommentRepository extends JpaRepository<ChallengeComment, Long>, CustomChallengeCommentRepository {
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ChallengeComment cc SET cc.isDeleted = true WHERE cc.challenge.id = :challengeId")
+    void softDeleteAllByChallengeId(@Param("challengeId") Long challengeId);
 }

--- a/src/main/java/com/cotato/itda/domain/challenge/repository/CustomChallengeCommentRepositoryImpl.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/repository/CustomChallengeCommentRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.cotato.itda.domain.challenge.entity.ChallengeComment;
 import com.cotato.itda.domain.challenge.entity.QChallengeComment;
 import com.cotato.itda.domain.member.entity.QMember;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +19,7 @@ public class CustomChallengeCommentRepositoryImpl implements CustomChallengeComm
     private final JPAQueryFactory jpaQueryFactory;
     QChallengeComment challengeComment = QChallengeComment.challengeComment;
     QMember member = QMember.member;
+    QChallengeComment child = new QChallengeComment("child");
 
     @Override
     public Slice<ChallengeComment> findComments(Long challengeId, Long memberId, Long lastId, PageRequest pageRequest) {
@@ -25,12 +27,23 @@ public class CustomChallengeCommentRepositoryImpl implements CustomChallengeComm
         List<ChallengeComment> comments = jpaQueryFactory
                 .selectFrom(challengeComment)
                 .join(challengeComment.member, member).fetchJoin()
+                .leftJoin(challengeComment.childComments, child).fetchJoin()
                 .where(
                         challengeComment.challenge.id.eq(challengeId),
-                        cursorCondition(lastId)
+                        challengeComment.parentComment.isNull(),
+                        cursorCondition(lastId),
+
+                        challengeComment.isDeleted.isFalse()
+                                .or(
+                                        JPAExpressions.selectFrom(child)
+                                                .where(child.parentComment.eq(challengeComment)
+                                                        .and(child.isDeleted.isFalse()))
+                                                .exists()
+                                )
                 )
                 .orderBy(challengeComment.id.asc())
                 .limit(pageRequest.getPageSize() + 1)
+                .distinct()
                 .fetch();
 
         boolean hasNext = comments.size() > pageRequest.getPageSize();

--- a/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommandService.java
@@ -5,6 +5,7 @@ import com.cotato.itda.domain.challenge.dto.request.ChallengeCreateRequest;
 import com.cotato.itda.domain.challenge.dto.response.ChallengeResponse;
 import com.cotato.itda.domain.challenge.entity.Challenge;
 import com.cotato.itda.domain.challenge.entity.ChallengeView;
+import com.cotato.itda.domain.challenge.repository.ChallengeCommentRepository;
 import com.cotato.itda.domain.challenge.repository.ChallengeRepository;
 import com.cotato.itda.domain.challenge.repository.ChallengeViewRepository;
 import com.cotato.itda.domain.member.entity.Member;
@@ -31,6 +32,7 @@ public class ChallengeCommandService {
     private final MissionRepository missionRepository;
     private final ChallengeRepository challengeRepository;
     private final ChallengeViewRepository challengeViewRepository;
+    private final ChallengeCommentRepository challengeCommentRepository;
 
     @Transactional
     public ChallengeResponse createChallenge(Long memberId, ChallengeCreateRequest request) {
@@ -71,6 +73,7 @@ public class ChallengeCommandService {
         }
 
         challenge.delete();
+        challengeCommentRepository.softDeleteAllByChallengeId(challengeId);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommentCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommentCommandService.java
@@ -43,8 +43,20 @@ public class ChallengeCommentCommandService {
 
         // 댓글 생성
         ChallengeComment comment = ChallengeCommentConverter.toEntity(challenge, member, request);
-        ChallengeComment savedComment = challengeCommentRepository.save(comment);
 
+        if (request.parentId() != null) {
+            ChallengeComment parentComment = challengeCommentRepository.findById(request.parentId())
+                    .orElseThrow(() -> new BusinessException(ChallengeErrorCode.COMMENT_NOT_FOUND));
+
+            // 댓글이 같은 챌린지의 댓글인지 한 번 더 검증
+            if (!parentComment.getChallenge().getId().equals(challengeId)) {
+                throw new BusinessException(ChallengeErrorCode.COMMENT_NOT_FOUND);
+            }
+
+            comment.setParent(parentComment);
+        }
+
+        ChallengeComment savedComment = challengeCommentRepository.save(comment);
         challenge.increaseComment();
 
         return ChallengeCommentConverter.toResponse(savedComment, member);

--- a/src/main/java/com/cotato/itda/domain/challenge/service/query/ChallengeCommentQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/query/ChallengeCommentQueryService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,26 +45,48 @@ public class ChallengeCommentQueryService {
         // 1. 댓글 조회
         PageRequest pageRequest = PageRequest.of(0, size);
         Slice<ChallengeComment> commentSlice = challengeCommentRepository.findComments(challengeId, memberId, lastId, pageRequest);
-        List<ChallengeComment> comments = commentSlice.getContent();
+        List<ChallengeComment> rootComments = commentSlice.getContent();
 
         // 2. 작성자 nickname Map 생성
-        Map<Long, String> nicknameMap = getFriendNicknameMap(memberId, comments);
+        Map<Long, String> nicknameMap = getFriendNicknameMap(memberId, rootComments);
 
-        // 3. Entity -> DTO 변환
-        List<ChallengeCommentListResponse.CommentItem> commentItems = comments.stream()
-                .map(comment -> {
-                    Member writer = comment.getMember();
+        List<ChallengeCommentListResponse.CommentItem> commentItems = rootComments.stream()
+                .map(root -> {
+                    Member writer = root.getMember();
+                    boolean isMe = writer.getId().equals(memberId);
 
-                    String nickname = writer.getId().equals(memberId)
+                    // 대댓글 변환: 부모댓글이 가지고 있는 대댓글 리스트를 순회하며 DTO 리스트로 변환
+                    List<ChallengeCommentListResponse.CommentItem> childItems = root.getChildComments().stream()
+                            .filter(child -> !child.getIsDeleted()) // 삭제된 댓글은 화면에서 숨김
+                            .map(child -> {
+                                boolean isChildMe = child.getMember().getId().equals(memberId);
+                                ChallengeCommentListResponse.WriterInfo childWriter = ChallengeCommentConverter.toListWriterInfo(child.getMember(), child.getMember().getName());
+
+                                // 대댓글은 하위에 자식이 없으므로 childComments 자리에 null을 넘김
+                                return ChallengeCommentConverter.toListItem(child, childWriter, null);
+                            })
+                            .toList();
+
+                    // 부모 댓글이 삭제 상태인 경우
+                    if (root.getIsDeleted()) {
+                        if (childItems.isEmpty()) {
+                            return null;
+                        }
+                        ChallengeCommentListResponse.WriterInfo unknownWriter =
+                                ChallengeCommentConverter.toListWriterInfo(null, "(알 수 없음)");
+
+                        return ChallengeCommentConverter.toDeletedListItem(root, unknownWriter, childItems);
+                    }
+
+                    String nickname = isMe
                             ? writer.getName()
                             : nicknameMap.getOrDefault(writer.getId(), writer.getName());
 
                     ChallengeCommentListResponse.WriterInfo writerInfo = ChallengeCommentConverter.toListWriterInfo(writer, nickname);
-
-                    return ChallengeCommentConverter.toListItem(comment, writerInfo);
+                    return ChallengeCommentConverter.toListItem(root, writerInfo, childItems);
                 })
+                .filter(Objects::nonNull)
                 .toList();
-
 
         // 4. 커서 ID 계산
         Long newLastId = commentItems.isEmpty() ? null : commentItems.get(commentItems.size() - 1).commentId();
@@ -91,5 +114,4 @@ public class ChallengeCommentQueryService {
                         Friendship::getDisplayName
                 ));
     }
-
 }

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -172,4 +172,11 @@ public class ChatRoomMember extends BaseTimeEntity {
 		this.inactiveAt = null;
 		this.joinSeq = newJoinSeq;
 	}
+
+    public void leaveWithResetHistory(long lastRoomSeq) {
+        this.status = MemberRoomStatus.LEFT;
+        this.inactiveAt = java.time.LocalDateTime.now();
+        this.joinSeq = lastRoomSeq;
+        this.lastReadSeq = lastRoomSeq;
+    }
 }

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -238,10 +238,15 @@ public class ChatRoomService {
 			roomId, memberId, MemberRoomStatus.ACTIVE
 		).orElseThrow(()-> new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_STATUS_INVALID));
 
-		chatRoomMember.leave();
+        // 나가기 직전 이 채팅방의 가장 마지막 메시지 시퀀스를 가져옴
+        Long lastRoomSeqObj = chatRoom.getLastMessageSeq();
+        long lastRoomSeq = (lastRoomSeqObj == null) ? 0L : lastRoomSeqObj;
 
+        // 내 멤버십의 시작선(joinSeq)을 현재 방의 최신 메시지 번호로 변경
+        chatRoomMember.leaveWithResetHistory(lastRoomSeq);
 
-	}
+        log.info("[채팅방 나가기 완료] memberId={}, roomId={}, 나가기 시점의 lastRoomSeq={}", memberId, roomId, lastRoomSeq);
+    }
 
 	// AI 모드 토글
 	@Transactional

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -3,8 +3,11 @@ package com.cotato.itda.domain.chat.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +42,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatRoomMemberRepository chatRoomMemberRepository;
 	private final FriendshipRepository friendshipRepository;
+	private final MemberRepository memberRepository;
 
 	public ChatRoomSliceResponse getMyRooms(
 		Long memberId,
@@ -59,12 +63,9 @@ public class ChatRoomService {
 			memberId, cursorAt, cursorRoomId, limitPlusOne
 		);
 
-		List<MyRoomRow> fetched = chatRoomQueryRepository.findMyRoomsSlice(
-			memberId,
-			cursorAt,
-			cursorRoomId,
-			limitPlusOne
-		);
+        List<MyRoomRow> fetched = chatRoomQueryRepository.findMyRoomsSlice(
+                memberId, cursorAt, cursorRoomId, limitPlusOne
+        );
 
 		log.info("[내 채팅방 목록 조회 결과] fetchedSize={}", fetched.size());
 
@@ -134,9 +135,14 @@ public class ChatRoomService {
 					? opponentMap.get(row.roomId())
 					: null;
 
-				Friendship friendship = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(memberId, opponentMap.get(row.roomId()).memberId(),
-					FriendshipStatus.ACTIVE)
-					.orElseThrow(()-> new BusinessException(ChatErrorCode.FRIENDSHIP_NOT_FOUND));
+                // 친구가 아니여도 프로필(opp) 유지
+                Long friendshipId = null;
+                if (row.roomType() == RoomType.DIRECT && opp != null) {
+                    friendshipId = friendshipRepository.findByMember_IdAndFriend_IdAndStatus(
+                                    memberId, opp.memberId(), FriendshipStatus.ACTIVE)
+                            .map(Friendship::getId)
+                            .orElse(null);
+                }
 
 				// 각 row마다 핵심값 로그 (너무 많으면 INFO가 과하니, 필요하면 DEBUG로 내려도 됨)
 				log.info("[방 아이템 계산] roomId={}, roomType={}, lastMessageSeq={}, lastReadSeq={}, joinSeq={}, effectiveReadSeq={}, unread={}, opponentMemberId={}",
@@ -157,11 +163,11 @@ public class ChatRoomService {
 					.lastMessageId(row.lastMessageId())
 					.lastMessageSeq(row.lastMessageSeq())
 					.lastMessageAt(row.lastMessageAt())
-					.friendShipId(friendship.getId())
+					.friendShipId(friendshipId)
 					.lastMessagePreview(row.lastMessagePreview())
 					.lastMessageType(row.lastMessageType())
 					.unreadCount(unread)
-					.opponent(row.roomType() == RoomType.DIRECT ? opp : null)
+					.opponent(opp)
 					.build();
 			})
 			.toList();
@@ -278,23 +284,35 @@ public class ChatRoomService {
 				return new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
 			});
 
-		ChatRoomMember myMembership = chatRoomMemberRepository.findByRoomIdAndMemberId(roomId, memberId)
-			.orElseThrow(() -> {
-				log.warn("[채팅방 ENTER 실패] 멤버십 없음. memberId={}, roomId={}", memberId, roomId);
-				return new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND);
-			});
+        Optional<ChatRoomMember> maybeMembership = chatRoomMemberRepository.findByRoomIdAndMemberId(roomId, memberId);
+        ChatRoomMember myMembership;
 
-		if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
-			log.warn("[채팅방 ENTER 거절] ACTIVE 아님. memberId={}, roomId={}, status={}",
-				memberId, roomId, myMembership.getStatus()
-			);
-			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
-		}
+        Long lastMessageSeqObj = room.getLastMessageSeq();
+        Long lastMessageId = room.getLastMessageId();
+        long lastSeq = (lastMessageSeqObj == null) ? 0L : lastMessageSeqObj;
 
-		Long lastMessageSeqObj = room.getLastMessageSeq();
-		Long lastMessageId = room.getLastMessageId();
+        // 이력이 없는 멤버
+        if (maybeMembership.isEmpty()) {
+            log.info("[채팅방 ENTER] 최초 입장 멤버 생성. memberId={}, roomId={}", memberId, roomId);
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
 
-		long lastSeq = (lastMessageSeqObj == null) ? 0L : lastMessageSeqObj;
+            myMembership = ChatRoomMember.create(member, room);
+            chatRoomMemberRepository.save(myMembership);
+            chatRoomMemberRepository.flush();
+        } else {
+            // 과거 이력이 존재하는 멤버 (예: LEFT 상태)
+            myMembership = maybeMembership.get();
+
+            if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
+                log.info("[채팅방 ENTER] 퇴장 유저 재입장 처리. memberId={}, roomId={}, 기존 status={}",
+                        memberId, roomId, myMembership.getStatus());
+
+                // 기존 레코드를 ACTIVE로 복구
+                myMembership.rejoin(lastSeq);
+                chatRoomMemberRepository.flush();
+            }
+        }
 
 		// 메시지 없으면 읽음 처리할 것도 없음
 		if (lastSeq <= 0L) {

--- a/src/main/java/com/cotato/itda/domain/diary/controller/DiaryCommentController.java
+++ b/src/main/java/com/cotato/itda/domain/diary/controller/DiaryCommentController.java
@@ -27,17 +27,20 @@ public class DiaryCommentController {
     private final DiaryCommentQueryService diaryCommentQueryService;
 
     @Operation(
-            summary = "공유일기 댓글 등록",
+            summary = "공유일기 댓글/대댓글 등록",
             description = """
                     pathVariable로 전달받은 특정 일기에 댓글을 등록합니다. 
                     - 등록 후 댓글 정보와 작성자 정보가 반환됩니다.
                     - 본인 또는 친구의 일기에만 댓글을 등록할 수 있습니다.
+                    - 대댓글 작성 시, Request Body에 부모 댓글 ID(`parentId`)를 포함해야 합니다.
+                    - 대댓글에 다시 대댓글을 달 경우 400 에러가 발생합니다.
                     """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "대댓글에 추가 대댓글 작성 불가 (Depth 2 제한)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "일기 접근 권한 없음 "),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID 또는 댓글 ID"),
     })
     @SecurityRequirement(name = "AccessToken")
     @PostMapping("/{diaryId}/comments")

--- a/src/main/java/com/cotato/itda/domain/diary/converter/DiaryCommentConverter.java
+++ b/src/main/java/com/cotato/itda/domain/diary/converter/DiaryCommentConverter.java
@@ -3,7 +3,6 @@ package com.cotato.itda.domain.diary.converter;
 import com.cotato.itda.domain.diary.dto.request.DiaryCommentRequest;
 import com.cotato.itda.domain.diary.dto.response.DiaryCommentListResponse;
 import com.cotato.itda.domain.diary.dto.response.DiaryCommentResponse;
-import com.cotato.itda.domain.diary.dto.response.DiaryListResponse;
 import com.cotato.itda.domain.diary.dto.response.WriterInfo;
 import com.cotato.itda.domain.diary.entity.Diary;
 import com.cotato.itda.domain.diary.entity.DiaryComment;
@@ -35,8 +34,9 @@ public class DiaryCommentConverter {
     }
 
     public static WriterInfo toWriterInfo(Member member, String nickname, boolean isMe) {
+        Long memberId = (member == null) ? null : member.getId();
         return WriterInfo.builder()
-                .memberId(member.getId())
+                .memberId(memberId)
                 .nickname(nickname) // 댓글 등록 응답의 경우, 내 프로필 이름
                 .profileImageUrl(member.getProfileImageUrl())
                 .isMe(isMe)
@@ -54,6 +54,7 @@ public class DiaryCommentConverter {
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .childComments(childComments != null ? childComments : new ArrayList<>()) // ◀ 대댓글 리스트 주입
+                .isDeleted(false)
                 .build();
     }
 
@@ -66,6 +67,21 @@ public class DiaryCommentConverter {
                 .comments(items)
                 .lastId(lastId)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    public static DiaryCommentListResponse.CommentItem toDeletedListItem(
+            DiaryComment root,
+            WriterInfo unknownWriter,
+            List<DiaryCommentListResponse.CommentItem> childItems
+    ) {
+        return DiaryCommentListResponse.CommentItem.builder()
+                .commentId(root.getId())
+                .content("삭제된 댓글입니다.")
+                .writerInfo(unknownWriter)
+                .childComments(childItems)
+                .createdAt(root.getCreatedAt())
+                .isDeleted(true)
                 .build();
     }
 }

--- a/src/main/java/com/cotato/itda/domain/diary/converter/DiaryCommentConverter.java
+++ b/src/main/java/com/cotato/itda/domain/diary/converter/DiaryCommentConverter.java
@@ -9,6 +9,7 @@ import com.cotato.itda.domain.diary.entity.Diary;
 import com.cotato.itda.domain.diary.entity.DiaryComment;
 import com.cotato.itda.domain.member.entity.Member;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DiaryCommentConverter {
@@ -22,8 +23,11 @@ public class DiaryCommentConverter {
     }
 
     public static DiaryCommentResponse toResponse(DiaryComment comment, WriterInfo writerInfo) {
+        Long parentId = (comment.getParentComment() != null) ? comment.getParentComment().getId() : null;
+
         return DiaryCommentResponse.builder()
                 .commentId(comment.getId())
+                .parentId(parentId)
                 .writerInfo(writerInfo)
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
@@ -39,12 +43,17 @@ public class DiaryCommentConverter {
                 .build();
     }
 
-    public static DiaryCommentListResponse.CommentItem toListItem(DiaryComment comment, WriterInfo writerInfo) {
+    public static DiaryCommentListResponse.CommentItem toListItem(
+            DiaryComment comment,
+            WriterInfo writerInfo,
+            List<DiaryCommentListResponse.CommentItem> childComments
+    ) {
         return DiaryCommentListResponse.CommentItem.builder()
                 .commentId(comment.getId())
                 .writerInfo(writerInfo)
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
+                .childComments(childComments != null ? childComments : new ArrayList<>()) // ◀ 대댓글 리스트 주입
                 .build();
     }
 

--- a/src/main/java/com/cotato/itda/domain/diary/dto/request/DiaryCommentRequest.java
+++ b/src/main/java/com/cotato/itda/domain/diary/dto/request/DiaryCommentRequest.java
@@ -9,6 +9,9 @@ public record DiaryCommentRequest(
         @Schema(description = "댓글 내용", example = "재밌었겠다")
         @NotBlank(message = "댓글 내용은 필수입니다.")
         @Size(min = 1, max = 5000, message = "댓글 내용은 1자 이상 5000자 이하여야 합니다.")
-        String content
+        String content,
+
+        @Schema(description = "부모 댓글 ID", example = "1")
+        Long parentId
 ) {
 }

--- a/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentListResponse.java
+++ b/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentListResponse.java
@@ -38,6 +38,9 @@ public record DiaryCommentListResponse(
             String content,
 
             @Schema(description = "작성 시간", example = "2026-01-10T10:00:00")
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+
+            @Schema(description = "대댓글 목록, 없을 경우 빈 배열이 반환됩니다.")
+            List<CommentItem> childComments
     ) {}
 }

--- a/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentListResponse.java
+++ b/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentListResponse.java
@@ -41,6 +41,9 @@ public record DiaryCommentListResponse(
             LocalDateTime createdAt,
 
             @Schema(description = "대댓글 목록, 없을 경우 빈 배열이 반환됩니다.")
-            List<CommentItem> childComments
+            List<CommentItem> childComments,
+
+            @Schema(description = "댓글 삭제 여부", example = "false")
+            boolean isDeleted
     ) {}
 }

--- a/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentResponse.java
+++ b/src/main/java/com/cotato/itda/domain/diary/dto/response/DiaryCommentResponse.java
@@ -8,8 +8,11 @@ import java.time.LocalDateTime;
 @Builder
 public record DiaryCommentResponse(
 
-        @Schema(description = "댓글 ID", example = "1")
+        @Schema(description = "댓글 ID", example = "2")
         Long commentId,
+
+        @Schema(description = "부모 댓글 ID", example = "1")
+        Long parentId,
 
         @Schema(description = "작성자 정보")
         WriterInfo writerInfo,

--- a/src/main/java/com/cotato/itda/domain/diary/entity/DiaryComment.java
+++ b/src/main/java/com/cotato/itda/domain/diary/entity/DiaryComment.java
@@ -1,12 +1,15 @@
 package com.cotato.itda.domain.diary.entity;
 
+import com.cotato.itda.domain.diary.exception.code.DiaryErrorCode;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.global.entity.BaseEntity;
+import com.cotato.itda.global.error.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
-
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -35,17 +38,28 @@ public class DiaryComment extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    // 추후 대댓글 기능 도입 시 사용
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "parent_id")
-//    private DiaryComment parentComment;
-//
-//    @OneToMany(mappedBy = "parentComment")
-//    @Builder.Default
-//    private List<DiaryComment> childComments = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private DiaryComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment")
+    @Builder.Default
+    private List<DiaryComment> childComments = new ArrayList<>();
 
     public void delete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void setParent(DiaryComment parent) {
+        if (parent == null) {
+            return;
+        }
+        // depth 2 제한
+        if (parent.getParentComment() != null) {
+            throw new BusinessException(DiaryErrorCode.REPLY_DEPTH_LIMIT);
+        }
+        this.parentComment = parent;
+        parent.getChildComments().add(this);
     }
 }

--- a/src/main/java/com/cotato/itda/domain/diary/entity/DiaryComment.java
+++ b/src/main/java/com/cotato/itda/domain/diary/entity/DiaryComment.java
@@ -17,7 +17,6 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Table(name = "diary_comment")
-@SQLRestriction("is_deleted = false")
 public class DiaryComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/cotato/itda/domain/diary/exception/code/DiaryErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/diary/exception/code/DiaryErrorCode.java
@@ -19,7 +19,8 @@ public enum DiaryErrorCode implements ErrorCode {
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다.", "DIARY_ERROR_404_COMMENT_NOT_FOUND"),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 댓글에 대한 권한이 없습니다.", "DIARY_ERROR_403_COMMENT_FORBIDDEN"),
-
+    REPLY_DEPTH_LIMIT(HttpStatus.BAD_REQUEST, "대댓글에는 추가 대댓글을 작성할 수 없습니다.", "DIARY_ERROR_400_REPLY_DEPTH_LIMIT"),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 부모 댓글을 찾을 수 없습니다.", "DIARY_ERROR_404_PARENT_COMMENT_NOT_FOUND"),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/cotato/itda/domain/diary/repository/CustomDiaryCommentRepositoryImpl.java
+++ b/src/main/java/com/cotato/itda/domain/diary/repository/CustomDiaryCommentRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.cotato.itda.domain.diary.entity.DiaryComment;
 import com.cotato.itda.domain.diary.entity.QDiaryComment;
 import com.cotato.itda.domain.member.entity.QMember;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +19,7 @@ public class CustomDiaryCommentRepositoryImpl implements CustomDiaryCommentRepos
     private final JPAQueryFactory jpaQueryFactory;
     QDiaryComment diaryComment = QDiaryComment.diaryComment;
     QMember member = QMember.member;
+    QDiaryComment child = new QDiaryComment("child");
 
     @Override
     public Slice<DiaryComment> findComments(Long diaryId, Long memberId, Long lastId, PageRequest pageRequest) {
@@ -25,14 +27,24 @@ public class CustomDiaryCommentRepositoryImpl implements CustomDiaryCommentRepos
         List<DiaryComment> comments = jpaQueryFactory
                 .selectFrom(diaryComment)
                 .join(diaryComment.member, member).fetchJoin() // member도 같이 조회
-                .leftJoin(diaryComment.childComments).fetchJoin()
+                .leftJoin(diaryComment.childComments, child).fetchJoin()
                 .where(
                         diaryComment.diary.id.eq(diaryId),
                         diaryComment.parentComment.isNull(),
-                        cursorCondition(lastId)
+                        cursorCondition(lastId),
+
+                        // 아직 삭제되지 않은 댓글이거나, 삭제되었더라도 대댓글이 남아 있는 경우에만 조회
+                        diaryComment.isDeleted.isFalse()
+                                .or(
+                                        JPAExpressions.selectFrom(child)
+                                                .where(child.parentComment.eq(diaryComment)
+                                                        .and(child.isDeleted.isFalse()))
+                                                .exists()
+                                )
                 )
                 .orderBy(diaryComment.id.asc())
                 .limit(pageRequest.getPageSize() + 1)
+                .distinct()
                 .fetch();
 
         boolean hasNext = comments.size() > pageRequest.getPageSize();

--- a/src/main/java/com/cotato/itda/domain/diary/repository/CustomDiaryCommentRepositoryImpl.java
+++ b/src/main/java/com/cotato/itda/domain/diary/repository/CustomDiaryCommentRepositoryImpl.java
@@ -25,8 +25,10 @@ public class CustomDiaryCommentRepositoryImpl implements CustomDiaryCommentRepos
         List<DiaryComment> comments = jpaQueryFactory
                 .selectFrom(diaryComment)
                 .join(diaryComment.member, member).fetchJoin() // member도 같이 조회
+                .leftJoin(diaryComment.childComments).fetchJoin()
                 .where(
                         diaryComment.diary.id.eq(diaryId),
+                        diaryComment.parentComment.isNull(),
                         cursorCondition(lastId)
                 )
                 .orderBy(diaryComment.id.asc())
@@ -47,5 +49,4 @@ public class CustomDiaryCommentRepositoryImpl implements CustomDiaryCommentRepos
         }
         return diaryComment.id.gt(lastId); // 댓글 오름차순 조회
     }
-
 }

--- a/src/main/java/com/cotato/itda/domain/diary/repository/DiaryCommentRepository.java
+++ b/src/main/java/com/cotato/itda/domain/diary/repository/DiaryCommentRepository.java
@@ -2,6 +2,14 @@ package com.cotato.itda.domain.diary.repository;
 
 import com.cotato.itda.domain.diary.entity.DiaryComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long>, CustomDiaryCommentRepository {
+    @Modifying
+    @Query("UPDATE DiaryComment dc SET dc.isDeleted = true, dc.deletedAt = :now WHERE dc.diary.id = :diaryId")
+    void softDeleteAllByDiaryId(@Param("diaryId") Long diaryId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
@@ -53,13 +53,6 @@ public class DiaryCommandService {
             throw new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN);
         }
 
-        // 날짜 변경하는 경우 일기 중복 확인
-        if (!diary.getDate().equals(request.date())) {
-            if (diaryRepository.existsByMemberIdAndDate(memberId, request.date())) {
-                throw new BusinessException(DiaryErrorCode.DIARY_ALREADY_EXISTS);
-            }
-        }
-
         diary.update(request.date(), request.emojiCode(), request.content(), request.imageUrl());
         return DiaryConverter.toResponse(diary);
     }

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
@@ -31,11 +31,6 @@ public class DiaryCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, Map.of("userId", memberId)));
 
-        // 해당 날짜 일기 중복 작성 방지 -> 편의상 임시로 주석 처리
-        // if (diaryRepository.existsByMemberIdAndDate(memberId, date)) {
-        //     throw new BusinessException(DiaryErrorCode.DIARY_ALREADY_EXISTS);
-        // }
-
         Diary diary = DiaryConverter.toEntity(request, date, member);
         Diary savedDiary = diaryRepository.save(diary);
 

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommandService.java
@@ -4,6 +4,7 @@ import com.cotato.itda.domain.diary.converter.DiaryConverter;
 import com.cotato.itda.domain.diary.dto.request.DiaryRequest;
 import com.cotato.itda.domain.diary.dto.response.DiaryResponse;
 import com.cotato.itda.domain.diary.entity.Diary;
+import com.cotato.itda.domain.diary.repository.DiaryCommentRepository;
 import com.cotato.itda.domain.diary.repository.DiaryRepository;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Service
@@ -24,6 +26,7 @@ public class DiaryCommandService {
 
     private final MemberRepository memberRepository;
     private final DiaryRepository diaryRepository;
+    private final DiaryCommentRepository diaryCommentRepository;
 
     @Transactional
     public DiaryResponse createDiary(Long memberId, DiaryRequest request, LocalDate date) {
@@ -71,6 +74,8 @@ public class DiaryCommandService {
             throw new BusinessException(DiaryErrorCode.DIARY_FORBIDDEN);
         }
 
+        // 해당 일기의 댓글 일괄 soft delete 처리
+        diaryCommentRepository.softDeleteAllByDiaryId(diaryId, LocalDateTime.now());
         diary.delete();
     }
 

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommentCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommentCommandService.java
@@ -42,8 +42,14 @@ public class DiaryCommentCommandService {
         // 일기 권한 검증
         diaryAccessValidator.validateDiaryAccess(memberId, diary);
 
-        // 댓글 생성
         DiaryComment comment = DiaryCommentConverter.toEntity(diary, member, request);
+
+        if (request.parentId() != null) {
+            DiaryComment parent = diaryCommentRepository.findById(request.parentId())
+                    .orElseThrow(() -> new BusinessException(DiaryErrorCode.PARENT_COMMENT_NOT_FOUND));
+            comment.setParent(parent);
+        }
+
         DiaryComment savedComment = diaryCommentRepository.save(comment);
 
         diary.increaseComment();

--- a/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryCommentQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryCommentQueryService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +57,7 @@ public class DiaryCommentQueryService {
 
                     // 대댓글 변환: 부모댓글이 가지고 있는 대댓글 리스트를 순회하며 DTO 리스트로 변환
                     List<DiaryCommentListResponse.CommentItem> childItems = root.getChildComments().stream()
+                            .filter(child -> !child.getIsDeleted()) // 삭제된 댓글은 화면에서 숨김
                             .map(child -> {
                                 boolean isChildMe = child.getMember().getId().equals(memberId);
                                 WriterInfo childWriter = DiaryCommentConverter.toWriterInfo(child.getMember(), child.getMember().getName(), isChildMe);
@@ -65,6 +67,20 @@ public class DiaryCommentQueryService {
                             })
                             .toList();
 
+                    // 부모 댓글이 삭제 상태인 경우
+                    if (root.getIsDeleted()) {
+                        if (childItems.isEmpty()) {
+                            return null;
+                        }
+                        WriterInfo unknownWriter = WriterInfo.builder()
+                                .memberId(null)
+                                .nickname("(알 수 없음)")
+                                .isMe(false)
+                                .build();
+
+                        return DiaryCommentConverter.toDeletedListItem(root, unknownWriter, childItems);
+                    }
+
                     String nickname = isMe
                             ? writer.getName()
                             : friendshipNicknameMap.getOrDefault(writer.getId(), writer.getName());
@@ -72,6 +88,7 @@ public class DiaryCommentQueryService {
                     WriterInfo writerInfo = DiaryCommentConverter.toWriterInfo(writer, nickname, isMe);
                     return DiaryCommentConverter.toListItem(root, writerInfo, childItems);
                 })
+                .filter(Objects::nonNull)
                 .toList();
 
         // 커서 ID 계산

--- a/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryCommentQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/query/DiaryCommentQueryService.java
@@ -44,22 +44,33 @@ public class DiaryCommentQueryService {
 
         PageRequest pageRequest = PageRequest.of(0, size);
         Slice<DiaryComment> commentSlice = diaryCommentRepository.findComments(diaryId, memberId, lastId, pageRequest);
-        List<DiaryComment> comments = commentSlice.getContent();
+        List<DiaryComment> rootComments = commentSlice.getContent();
 
         // 작성자의 friendship nickname Map 조회
-        Map<Long, String> friendshipNicknameMap = getFriendNicknameMap(memberId, comments);
+        Map<Long, String> friendshipNicknameMap = getFriendNicknameMap(memberId, rootComments);
 
-        List<DiaryCommentListResponse.CommentItem> commentItems = comments.stream()
-                .map(comment -> {
-                    Member writer = comment.getMember();
+        List<DiaryCommentListResponse.CommentItem> commentItems = rootComments.stream()
+                .map(root -> {
+                    Member writer = root.getMember();
                     boolean isMe = writer.getId().equals(memberId);
+
+                    // 대댓글 변환: 부모댓글이 가지고 있는 대댓글 리스트를 순회하며 DTO 리스트로 변환
+                    List<DiaryCommentListResponse.CommentItem> childItems = root.getChildComments().stream()
+                            .map(child -> {
+                                boolean isChildMe = child.getMember().getId().equals(memberId);
+                                WriterInfo childWriter = DiaryCommentConverter.toWriterInfo(child.getMember(), child.getMember().getName(), isChildMe);
+
+                                // 대댓글은 하위에 자식이 없으므로 childComments 자리에 null을 넘김
+                                return DiaryCommentConverter.toListItem(child, childWriter, null);
+                            })
+                            .toList();
 
                     String nickname = isMe
                             ? writer.getName()
                             : friendshipNicknameMap.getOrDefault(writer.getId(), writer.getName());
 
                     WriterInfo writerInfo = DiaryCommentConverter.toWriterInfo(writer, nickname, isMe);
-                    return DiaryCommentConverter.toListItem(comment, writerInfo);
+                    return DiaryCommentConverter.toListItem(root, writerInfo, childItems);
                 })
                 .toList();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 채팅방 재입장 시 상대방 프로필이 '알 수 없음'으로 뜨는 에러를 해결했습니다.
    - 기존에는사용자가 일대일 채팅방을 나간 후(`LEFT` 상태) 또는 상대방과 친구 관계가 활성화(`ACTIVE`)되어 있지 않은 경우, 목록 조회하면 상대방 정보가 '알 수 없음'으로 노출되는 현상이 있었습니다.
   - 대화 상대방의 기본 프로필 정보(`OpponentSummaryDto`)는 유지 및 반환되도록 DTO 조립 로직을 개선했습니다.

- 채팅방 퇴장 시 기존 채팅방 히스토리를 삭제하도록 구현했습니다.
   - 유저가 채팅방 퇴장 시 실제 메시지 데이터를 hard delete하는 대신에 해당 방의 최신 메시지 번호(`lastMessageSeq`)를 나의 채팅 참여 시작선(`joinSeq` 및 `lastReadSeq`)으로 동기화시키는 메서드를 구현했습니다. 
   - 재입장 시 `unreadCount`가 `0`으로 초기화되며, 사용자가 재입장한 시점 이후의 메시지만 화면에 렌더링되도록 수정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
