### PR TITLE
[fix] 채팅방 퇴장 후 첫 메시지 누락 버그 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomMemberRepository.java
@@ -55,4 +55,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 		@Param("status") MemberRoomStatus status,
 		@Param("roomIds") List<Long> roomIds
 	);
+
+    List<ChatRoomMember> findAllByRoomId(Long roomId);
 }

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -159,20 +159,28 @@ public class ChatMessageService {
 		long lastSeq = (lastMessageSeq == null) ? 0L : lastMessageSeq;
 		long nextSeq = lastSeq + 1;
 
+        // 내가 나간 상태였다면 채팅방 복구
 		if (myMembership.getStatus() == MemberRoomStatus.LEFT) {
 			myMembership.rejoin(nextSeq);
 		}
+
+        // 내가 메시지를 보냈을 때, 상대방이 나가기(LEFT) 상태라면 상대방의 방 상태를 ACTIVE로 복구시키고 joinSeq 보정
+        List<ChatRoomMember> allMembers = chatRoomMemberRepository.findAllByRoomId(roomId);
+        for (ChatRoomMember member : allMembers) {
+            if (!member.getMember().getId().equals(senderMemberId)) {
+                if (member.getStatus() == MemberRoomStatus.LEFT) {
+                    log.info("[상대방 방 강제 복구] opponentMemberId={}, joinSeq 보정={}", member.getMember().getId(), lastSeq);
+                    member.rejoin(lastSeq);
+                }
+            }
+        }
 		log.info("[seq 발급] roomId={}, lastSeq={}, nextSeq={}", roomId, lastSeq, nextSeq);
 
-		ChatMessage message = ChatMessage.createChatMessage(
-			sender,
-			room,
-			nextSeq,
-			req.messageType(),
-			req.content()
-		);
+        ChatMessage message = ChatMessage.createChatMessage(
+                sender, room, nextSeq, req.messageType(), req.content()
+        );
+        chatMessageRepository.save(message);
 
-		chatMessageRepository.save(message);
 		log.info("[메시지 저장 완료] roomId={}, messageId={}, messageSeq={}, senderMemberId={}, messageType={}",
 			roomId, message.getId(), message.getMessageSeq(), senderMemberId, req.messageType()
 		);
@@ -225,9 +233,11 @@ public class ChatMessageService {
 		);
 
 		// ===== [7] 상대 ID 추출 =====
-		Long opponentId = chatRoomMemberRepository
-			.findOpponentMemberId(roomId, senderMemberId, MemberRoomStatus.ACTIVE)
-			.orElse(null);
+        Long opponentId = allMembers.stream()
+                .map(m -> m.getMember().getId())
+                .filter(id -> !id.equals(senderMemberId))
+                .findFirst()
+                .orElse(null);
 
 		log.info("[상대 조회] roomId={}, senderMemberId={}, opponentId={}",
 			roomId, senderMemberId, opponentId
@@ -321,17 +331,10 @@ public class ChatMessageService {
 			senderMemberId, userQueueDest, roomId, message.getId(), nextSeq
 		);
 
-		if (opponentId != null) {
-			messagingTemplate.convertAndSendToUser(
-				String.valueOf(opponentId),
-				userQueueDest,
-				listUpdated
-			);
-
-			log.info("[개인 이벤트 발행] (ROOM_LIST_UPDATED) toUser={}, dest=/user{}, roomId={}, lastMessageId={}, lastSeq={}",
-				opponentId, userQueueDest, roomId, message.getId(), nextSeq
-			);
-		} else {
+        if (opponentId != null) {
+            messagingTemplate.convertAndSendToUser(String.valueOf(opponentId), userQueueDest, listUpdated);
+            log.info("[실시간 목록 갱신 발행 완료] 수신 유저: {}", opponentId);
+        } else {
 			log.warn("[상대 없음] 1:1방에서 상대가 나갔거나 ACTIVE 아님. roomId={}, senderMemberId={}", roomId, senderMemberId);
 		}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 채팅방 퇴장 후 다른 유저가 메시지를 보냈을 때, 첫 번째 메시지가 누락되는 버그를 수정했습니다.
- 메시지가 DB에 저장되기 전에 상대방의 상태가 `LEFT`라면 방 상태를 `ACTIVE`로 복구하고 `joinSeq`를 현재 보낼 메시지 번호보다 1 작은 `lastSeq`로 보정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
