### PR TITLE
[fix] 채팅방 재입장 시 이전 메시지 노출 오류 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -176,7 +176,9 @@ public class ChatRoomMember extends BaseTimeEntity {
     public void leaveWithResetHistory(long lastRoomSeq) {
         this.status = MemberRoomStatus.LEFT;
         this.inactiveAt = java.time.LocalDateTime.now();
-        this.joinSeq = lastRoomSeq;
-        this.lastReadSeq = lastRoomSeq;
+
+        long nextSeqPoint = lastRoomSeq + 1;
+        this.joinSeq = nextSeqPoint;
+        this.lastReadSeq = nextSeqPoint;
     }
 }

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -350,24 +350,21 @@ public class ChatMessageService {
 			memberId, roomId, limit, cursorSeq
 		);
 
-		// 권한 체크
-		chatRoomMemberRepository
-			.findOneByRoomMemberStatus(roomId, memberId, MemberRoomStatus.ACTIVE)
-			.orElseThrow(() -> {
-				log.warn("[히스토리 권한 실패] memberId={} 는 roomId={} ACTIVE 멤버 아님", memberId, roomId);
-				return new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
-			});
-
 		int safeLimit = (limit == null) ? 30 : Math.min(Math.max(limit, 1), 100);
 		int limitPlusOne = safeLimit + 1;
 
-		log.info("[히스토리 조회 파라미터] safeLimit={}, limitPlusOne={}, cursorSeq={}", safeLimit, limitPlusOne, cursorSeq);
-		ChatRoomMember myMembership = chatRoomMemberRepository
-			.findByRoomIdAndMemberId(roomId, memberId)
-			.orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
+        // 권한 체크
+        ChatRoomMember myMembership = chatRoomMemberRepository
+                .findByRoomIdAndMemberId(roomId, memberId)
+                .orElseThrow(() -> {
+                    log.warn("[히스토리 권한 실패] memberId={} 는 roomId={} ACTIVE 멤버 아님", memberId, roomId);
+                    return new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND);
+                });
+
 		if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
 			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
 		}
+
 		// 내가 볼 수 있는 최초 메시지 시퀀스
 		// 재입장 이후 메시지부터 보임
 		// null이면 처음부터 다 보여줌

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -319,29 +319,6 @@ public class ChatRoomService {
             }
         }
 
-        if (maybeMembership.isEmpty()) {
-            // 처음 입장하는 멤버이면 신규 생성
-            log.info("[채팅방 ENTER] 최초 입장 멤버 생성. memberId={}, roomId={}", memberId, roomId);
-            Member member = memberRepository.findById(memberId) // 필요 시 주입받아 사용
-                    .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
-
-            myMembership = ChatRoomMember.create(member, room);
-            chatRoomMemberRepository.save(myMembership);
-            chatRoomMemberRepository.flush();
-
-        } else {
-            // 기존 기록이 있는 멤버
-            myMembership = maybeMembership.get();
-
-            if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
-                log.info("[채팅방 ENTER] 퇴장 유저 재입장 처리. memberId={}, roomId={}, 기존 status={}",
-                        memberId, roomId, myMembership.getStatus());
-
-                myMembership.rejoin(lastSeq);
-                chatRoomMemberRepository.flush();
-            }
-        }
-
 		// 메시지 없으면 읽음 처리할 것도 없음
 		if (lastSeq <= 0L) {
 			log.info("[채팅방 ENTER 읽음처리 생략] roomId={}, memberId={} (메시지 없음)", roomId, memberId);


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 채팅방 나가기 후 재입장 시 이전 메시지 1개가 노출되는 오류를 수정했습니다.
- ChatRoomMember 퇴장 시 joinSeq를 lastRoomSeq + 1로 수정했습니다.
- ChatRoomService의 enterRoom 메서드 내 중복 연속 호출되던 코드를 제거했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
