### PR TITLE
[fix] 채팅방 재입장 시 메시지 노출 오류 수정 및 상대방 프로필 누락 오류 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -181,4 +181,9 @@ public class ChatRoomMember extends BaseTimeEntity {
         this.joinSeq = nextSeqPoint;
         this.lastReadSeq = nextSeqPoint;
     }
+
+    public void changeStatus(MemberRoomStatus status) {
+        this.status = status;
+        this.inactiveAt = null;
+    }
 }

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
@@ -129,7 +129,7 @@ public class ChatRoomQueryRepository {
 				chatRoomMember.room.id.in(roomIds)
 					// ne: not equal -> 같지 않은 값
 					.and(chatRoomMember.member.id.ne(myMemberId))
-					.and(chatRoomMember.status.eq(MemberRoomStatus.ACTIVE))
+                    .and(chatRoomMember.status.ne(MemberRoomStatus.KICKED))
 			)
 			.fetch();
 	}

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.itda.domain.chat.controller.dto.ChatRoomListItemDto;
@@ -131,6 +132,8 @@ public class ChatRoomService {
 				long lastMessageSeq = (row.lastMessageSeq() == null) ? 0L : row.lastMessageSeq();
 				long unread = Math.max(0L, lastMessageSeq - effectiveReadSeq);
 
+                boolean isPastMessage = lastMessageSeq < row.joinSeq();
+
 				OpponentSummaryDto opp = (row.roomType() == RoomType.DIRECT)
 					? opponentMap.get(row.roomId())
 					: null;
@@ -160,12 +163,12 @@ public class ChatRoomService {
 					.roomId(row.roomId())
 					.roomType(row.roomType())
 					.roomName(row.roomName())
-					.lastMessageId(row.lastMessageId())
-					.lastMessageSeq(row.lastMessageSeq())
+                    .lastMessageId(isPastMessage ? null : row.lastMessageId())
+                    .lastMessageSeq(isPastMessage ? null : row.lastMessageSeq())
 					.lastMessageAt(row.lastMessageAt())
 					.friendShipId(friendshipId)
-					.lastMessagePreview(row.lastMessagePreview())
-					.lastMessageType(row.lastMessageType())
+                    .lastMessagePreview(isPastMessage ? null : row.lastMessagePreview())
+                    .lastMessageType(isPastMessage ? null : row.lastMessageType())
 					.unreadCount(unread)
 					.opponent(opp)
 					.build();
@@ -303,20 +306,19 @@ public class ChatRoomService {
                     .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_MEMBER_NOT_FOUND));
 
             myMembership = ChatRoomMember.create(member, room);
+            myMembership.changeStatus(MemberRoomStatus.ACTIVE);
             chatRoomMemberRepository.save(myMembership);
-            chatRoomMemberRepository.flush();
         } else {
             // 과거 이력이 존재하는 멤버 (예: LEFT 상태)
             myMembership = maybeMembership.get();
 
-            if (myMembership.getStatus() != MemberRoomStatus.ACTIVE) {
-                log.info("[채팅방 ENTER] 퇴장 유저 재입장 처리. memberId={}, roomId={}, 기존 status={}",
-                        memberId, roomId, myMembership.getStatus());
+            log.info("[채팅방 ENTER] 기존 이력 존재 멤버 처리. memberId={}, roomId={}, 기존 status={}",
+                    memberId, roomId, myMembership.getStatus());
 
-                // 기존 레코드를 ACTIVE로 복구
-                myMembership.rejoin(lastSeq);
-                chatRoomMemberRepository.flush();
-            }
+            myMembership.changeStatus(MemberRoomStatus.ACTIVE);
+
+            chatRoomMemberRepository.saveAndFlush(myMembership);
+            log.info("[채팅방 ENTER] 변경 완료 후 즉시 플러시 성공. status={}", myMembership.getStatus());
         }
 
 		// 메시지 없으면 읽음 처리할 것도 없음
@@ -333,7 +335,13 @@ public class ChatRoomService {
 			return;
 		}
 
-		// 복구되거나 새로 생성된 멤버십 상태에서 최종 읽음 처리 수행
+        if (myMembership.getJoinSeq() > lastSeq) {
+            log.info("[채팅방 ENTER] 재입장 유저이므로 기존 읽음 처리 스킵 (joinSeq={}, lastSeq={})",
+                    myMembership.getJoinSeq(), lastSeq);
+            return;
+        }
+
+		// 최초 입장했거나 정상 대화 중인 멤버만 최종 읽음 처리 수행
 		myMembership.markRead(lastSeq, lastMessageId);
 
 		log.info("[채팅방 ENTER 완료] memberId={}, roomId={}, readSeq={}, readMessageId={}",


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 상대방이 방을 나가 `LEFT` 상태가 되면, 목록 조회 시 `ACTIVE`인 멤버만 필터링하여 상대방 프로필 정보가 누락되는 오류를 해결했습니다.
- 재입장 시 채팅방의 이전 히스토리를 볼 수 없도록 수정했습니다/

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
