### PR TITLE
[fix] 양쪽 퇴장 후 메시지 발송 시 상대방 unreadCount 누락 오류 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -169,8 +169,9 @@ public class ChatMessageService {
         for (ChatRoomMember member : allMembers) {
             if (!member.getMember().getId().equals(senderMemberId)) {
                 if (member.getStatus() == MemberRoomStatus.LEFT) {
-                    log.info("[상대방 방 강제 복구] opponentMemberId={}, joinSeq 보정={}", member.getMember().getId(), lastSeq);
-                    member.rejoin(lastSeq);
+                    log.info("[상대방 방 강제 복구 완료] opponentMemberId={}, joinSeq 시작선 싱크={}",
+                            member.getMember().getId(), nextSeq);
+                    member.rejoin(nextSeq);
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 양쪽 다 채팅방을 나간 상태(`LEFT`)에서 한 명이 다른 사람에게 메세지를 보낼 때, 받는 사람 시점에서 `unreadCount`가 1개 유실되는 오류를 수정했습니다.
- `ChatMessageService.sendMessage` 로직 중 상대방 방 상태를 복구하는 구간에서,  새로 생성되는 메시지 시퀀스를 타임라인 시작선으로 고정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
