### PR TITLE
[fix] 채팅방 나가기 후 메시지 unreadCount 누락 오류 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatRoomMember.java
@@ -177,9 +177,8 @@ public class ChatRoomMember extends BaseTimeEntity {
         this.status = MemberRoomStatus.LEFT;
         this.inactiveAt = java.time.LocalDateTime.now();
 
-        long nextSeqPoint = lastRoomSeq + 1;
-        this.joinSeq = nextSeqPoint;
-        this.lastReadSeq = nextSeqPoint;
+        this.joinSeq = lastRoomSeq + 1;
+        this.lastReadSeq = lastRoomSeq;
     }
 
     public void changeStatus(MemberRoomStatus status) {

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -169,9 +169,8 @@ public class ChatMessageService {
         for (ChatRoomMember member : allMembers) {
             if (!member.getMember().getId().equals(senderMemberId)) {
                 if (member.getStatus() == MemberRoomStatus.LEFT) {
-                    log.info("[상대방 방 강제 복구 완료] opponentMemberId={}, joinSeq 시작선 싱크={}",
-                            member.getMember().getId(), nextSeq);
-                    member.rejoin(nextSeq);
+                    log.info("[상대방 방 강제 복구] opponentMemberId={}, joinSeq 시작선={}", member.getMember().getId(), lastSeq);
+                    member.rejoin(lastSeq);
                 }
             }
         }

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatRoomService.java
@@ -128,8 +128,8 @@ public class ChatRoomService {
 		// ===== [4] unread_count 계산 + DTO 조립 =====
 		List<ChatRoomListItemDto> items = page.stream()
 			.map(row -> {
-				long effectiveReadSeq = Math.max(row.lastReadSeq(), row.joinSeq());
-				long lastMessageSeq = (row.lastMessageSeq() == null) ? 0L : row.lastMessageSeq();
+                long effectiveReadSeq = Math.max(row.lastReadSeq(), row.joinSeq() - 1L);
+                long lastMessageSeq = (row.lastMessageSeq() == null) ? 0L : row.lastMessageSeq();
 				long unread = Math.max(0L, lastMessageSeq - effectiveReadSeq);
 
                 boolean isPastMessage = lastMessageSeq < row.joinSeq();


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- `effectiveReadSeq` 계산 시 `joinSeq - 1` 로 적용하여 채팅방 나가기 후 메시지 unreadCount 누락 오류를 수정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
