### PR TITLE
[fix] 상대방 퇴장 상태일 때 메시지 전송 시 joinSeq 보정 오류 수정

### DIFF
--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -143,7 +143,6 @@ public class ChatMessageService {
 			throw new BusinessException(ChatErrorCode.CHAT_ROOM_MEMBER_CREATE_FORBIDDEN);
 		}
 
-
 		log.info("[권한 체크 성공] senderMemberId={} 는 roomId={} ACTIVE 멤버", senderMemberId, roomId);
 
 		// ===== [4] seq 발급 + 메시지 저장 (비관적 락) =====
@@ -169,8 +168,8 @@ public class ChatMessageService {
         for (ChatRoomMember member : allMembers) {
             if (!member.getMember().getId().equals(senderMemberId)) {
                 if (member.getStatus() == MemberRoomStatus.LEFT) {
-                    log.info("[상대방 방 강제 복구] opponentMemberId={}, joinSeq 시작선={}", member.getMember().getId(), lastSeq);
-                    member.rejoin(lastSeq);
+                    log.info("[상대방 방 강제 복구] opponentMemberId={}, joinSeq 시작선={}", member.getMember().getId(), nextSeq);
+                    member.rejoin(nextSeq);
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#133 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 둘 다 퇴장한 상태에서 A가 메시지를 보낼 때, LEFT 상태인 B의 joinSeq가 lastSeq로 설정되던 문제를 수정했습니다.
- B의 joinSeq가 과거 마지막 메시지 시퀀스로 지정되어, 재입장 시 이전 마지막 메시지가 중복 노출되는 에러를 해결했습니다.
- B의 rejoin 시점을 현재 생성된 메시지 시퀀스(nextSeq)로 변경하여 새 메시지만 보이도록 보정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
