### PR TITLE
[fix] 친구 관심 주제 교체 처리

### DIFF
--- a/src/main/java/com/cotato/itda/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/entity/Friendship.java
@@ -1,5 +1,6 @@
 package com.cotato.itda.domain.friendship.entity;
 
+import com.cotato.itda.domain.chattopic.entity.ChatTopic;
 import com.cotato.itda.domain.friendship.entity.mapping.FriendshipTopic;
 import com.cotato.itda.domain.friendship.enums.ChatGoal;
 import com.cotato.itda.domain.friendship.enums.FriendshipStatus;
@@ -12,6 +13,8 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Builder
@@ -65,6 +68,29 @@ public class Friendship extends BaseEntity {
             this.chatGoal = chatGoal;
         if (status != null)
             this.status = status;
+    }
+
+    public void replaceTopics(List<ChatTopic> topics) {
+        Set<String> requestedCodes = topics.stream()
+                .map(ChatTopic::getCode)
+                .collect(Collectors.toSet());
+
+        friendshipTopics.removeIf(friendshipTopic ->
+                !requestedCodes.contains(friendshipTopic.getChatTopic().getCode()));
+
+        Set<String> existingCodes = friendshipTopics.stream()
+                .map(friendshipTopic -> friendshipTopic.getChatTopic().getCode())
+                .collect(Collectors.toSet());
+
+        List<FriendshipTopic> topicsToAdd = topics.stream()
+                .filter(topic -> !existingCodes.contains(topic.getCode()))
+                .map(topic -> FriendshipTopic.builder()
+                        .friendship(this)
+                        .chatTopic(topic)
+                        .build())
+                .toList();
+
+        friendshipTopics.addAll(topicsToAdd);
     }
 
     public String getDisplayName() {

--- a/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
@@ -13,7 +13,6 @@ import com.cotato.itda.domain.friendship.enums.FriendshipStatus;
 import com.cotato.itda.domain.friendship.exception.FriendshipException;
 import com.cotato.itda.domain.friendship.exception.code.FriendshipErrorCode;
 import com.cotato.itda.domain.friendship.repository.FriendshipRepository;
-import com.cotato.itda.domain.friendship.repository.FriendshipTopicRepository;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
 import com.cotato.itda.global.error.constant.UserErrorCode;
@@ -35,7 +34,6 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
         private final FriendshipRepository friendshipRepository;
         private final MemberRepository memberRepository;
         private final ChatTopicRepository chatTopicRepository;
-        private final FriendshipTopicRepository friendshipTopicRepository;
 
         @Transactional
         @Override
@@ -95,8 +93,8 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
                 // 2. 기존 주제 조회
                 List<FriendshipTopic> existingTopics = friendship.getFriendshipTopics();
 
-                // 3. 변경분 계산 및 처리
-                updateTopicChanges(friendship, requestedTopics, existingTopics);
+                // 3. 요청한 주제 목록이 최종 상태가 되도록 교체
+                replaceTopicChanges(friendship, requestedTopics, existingTopics);
         }
 
         private List<ChatTopic> validateAndFetchTopics(List<String> topicCodes) {
@@ -119,7 +117,7 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
                 return topics;
         }
 
-        private void updateTopicChanges(
+        private void replaceTopicChanges(
                         Friendship friendship,
                         List<ChatTopic> requestedTopics,
                         List<FriendshipTopic> existingTopics) {
@@ -131,11 +129,6 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
                                 .map(ft -> ft.getChatTopic().getCode())
                                 .collect(Collectors.toSet());
 
-                // 삭제할 항목 (기존에 있었는데 요청에 없는 것)
-                List<FriendshipTopic> topicsToDelete = existingTopics.stream()
-                                .filter(ft -> !requestedCodes.contains(ft.getChatTopic().getCode()))
-                                .toList();
-
                 // 추가할 항목 (요청에 있는데 기존에 없는 것)
                 List<FriendshipTopic> topicsToAdd = requestedTopics.stream()
                                 .filter(topic -> !existingCodes.contains(topic.getCode()))
@@ -145,13 +138,8 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
                                                 .build())
                                 .toList();
 
-                // 저장
-                if (!topicsToDelete.isEmpty()) {
-                        friendshipTopicRepository.deleteAll(topicsToDelete);
-                }
-                if (!topicsToAdd.isEmpty()) {
-                        friendshipTopicRepository.saveAll(topicsToAdd);
-                }
+                existingTopics.removeIf(ft -> !requestedCodes.contains(ft.getChatTopic().getCode()));
+                existingTopics.addAll(topicsToAdd);
         }
 
         @Override

--- a/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/friendship/service/command/FriendshipCommandServiceImpl.java
@@ -8,7 +8,6 @@ import com.cotato.itda.domain.chattopic.exception.ChatTopicException;
 import com.cotato.itda.domain.chattopic.exception.code.ChatTopicErrorCode;
 import com.cotato.itda.domain.chattopic.repository.ChatTopicRepository;
 import com.cotato.itda.domain.friendship.entity.Friendship;
-import com.cotato.itda.domain.friendship.entity.mapping.FriendshipTopic;
 import com.cotato.itda.domain.friendship.enums.FriendshipStatus;
 import com.cotato.itda.domain.friendship.exception.FriendshipException;
 import com.cotato.itda.domain.friendship.exception.code.FriendshipErrorCode;
@@ -87,14 +86,8 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
         }
 
         private void updateFriendshipTopics(Friendship friendship, List<String> topicCodes) {
-                // 1. 요청한 주제 검증 및 조회
                 List<ChatTopic> requestedTopics = validateAndFetchTopics(topicCodes);
-
-                // 2. 기존 주제 조회
-                List<FriendshipTopic> existingTopics = friendship.getFriendshipTopics();
-
-                // 3. 요청한 주제 목록이 최종 상태가 되도록 교체
-                replaceTopicChanges(friendship, requestedTopics, existingTopics);
+                friendship.replaceTopics(requestedTopics);
         }
 
         private List<ChatTopic> validateAndFetchTopics(List<String> topicCodes) {
@@ -115,31 +108,6 @@ public class FriendshipCommandServiceImpl implements FriendshipCommandService {
                 }
 
                 return topics;
-        }
-
-        private void replaceTopicChanges(
-                        Friendship friendship,
-                        List<ChatTopic> requestedTopics,
-                        List<FriendshipTopic> existingTopics) {
-                Set<String> requestedCodes = requestedTopics.stream()
-                                .map(ChatTopic::getCode)
-                                .collect(Collectors.toSet());
-
-                Set<String> existingCodes = existingTopics.stream()
-                                .map(ft -> ft.getChatTopic().getCode())
-                                .collect(Collectors.toSet());
-
-                // 추가할 항목 (요청에 있는데 기존에 없는 것)
-                List<FriendshipTopic> topicsToAdd = requestedTopics.stream()
-                                .filter(topic -> !existingCodes.contains(topic.getCode()))
-                                .map(topic -> FriendshipTopic.builder()
-                                                .friendship(friendship)
-                                                .chatTopic(topic)
-                                                .build())
-                                .toList();
-
-                existingTopics.removeIf(ft -> !requestedCodes.contains(ft.getChatTopic().getCode()));
-                existingTopics.addAll(topicsToAdd);
         }
 
         @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

- #141

## 📝작업 내용

PATCH /friendships/{id}에서 전달된 topicCodes 배열이 친구 관심 주제의 최종 목록이 되도록 수정했습니다. 기존에는 제거된 주제가 응답 및 영속성 컨텍스트에 남을 수 있었으나, 이제 요청에 없는 기존 주제는 제거되고 요청에 새로 포함된 주제만 추가됩니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

없음

## 💬리뷰 요구사항 

- `Friendship.friendshipTopics` 컬렉션을 직접 갱신해 `orphanRemoval = true`로 제거 대상이 삭제되도록 한 부분을 중점적으로 확인 부탁드립니다.