### PR TITLE
[feat] 인앱 알림 API 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/cotato/itda/domain/notification/controller/NotificationController.java
@@ -1,0 +1,100 @@
+package com.cotato.itda.domain.notification.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
+import com.cotato.itda.domain.notification.service.NotificationService;
+import com.cotato.itda.global.common.response.ApiResponse;
+import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+@Tag(name = "Notification", description = "인앱 알림 API")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@Operation(
+		summary = "내 알림 목록 조회",
+		description = """
+			로그인한 사용자의 인앱 알림 목록을 최신순으로 조회합니다.
+			- 첫 조회: lastId 없이 요청합니다.
+			- 추가 조회: 응답의 hasNext가 true인 경우 lastId를 다음 요청에 포함합니다.
+			"""
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청 파라미터")
+	})
+	@SecurityRequirement(name = "AccessToken")
+	@GetMapping
+	public ApiResponse<NotificationListResponse> getNotifications(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+
+		@Parameter(description = "직전 조회 응답의 lastId 값 (첫 조회 요청 시 null)", example = "10")
+		@RequestParam(required = false) Long lastId,
+
+		@Parameter(description = "조회할 알림 개수 (기본 20, 최대 50)", example = "20")
+		@RequestParam(required = false, defaultValue = "20")
+		@Min(value = 1, message = "limit은 1 이상이어야 합니다.")
+		@Max(value = 50, message = "limit은 50 이하이어야 합니다.")
+		int limit
+	) {
+		NotificationListResponse response = notificationService.getNotifications(jwtPrincipal.memberId(), lastId, limit);
+		return ApiResponse.success(response);
+	}
+
+	@Operation(summary = "내 미읽음 알림 개수 조회", description = "로그인한 사용자의 읽지 않은 알림 개수를 조회합니다.")
+	@SecurityRequirement(name = "AccessToken")
+	@GetMapping("/unread-count")
+	public ApiResponse<UnreadNotificationCountResponse> getUnreadCount(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal
+	) {
+		UnreadNotificationCountResponse response = notificationService.getUnreadCount(jwtPrincipal.memberId());
+		return ApiResponse.success(response);
+	}
+
+	@Operation(summary = "알림 단건 읽음 처리", description = "로그인한 사용자의 특정 알림을 읽음 처리합니다.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "타인의 알림 접근"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 알림")
+	})
+	@SecurityRequirement(name = "AccessToken")
+	@PatchMapping("/{notificationId}/read")
+	public ApiResponse<Void> markAsRead(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+		@Parameter(description = "읽음 처리할 알림 ID", required = true, example = "1")
+		@PathVariable Long notificationId
+	) {
+		notificationService.markAsRead(jwtPrincipal.memberId(), notificationId);
+		return ApiResponse.success(null);
+	}
+
+	@Operation(summary = "내 알림 전체 읽음 처리", description = "로그인한 사용자의 모든 미읽음 알림을 읽음 처리합니다.")
+	@SecurityRequirement(name = "AccessToken")
+	@PatchMapping("/read-all")
+	public ApiResponse<Void> markAllAsRead(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal
+	) {
+		notificationService.markAllAsRead(jwtPrincipal.memberId());
+		return ApiResponse.success(null);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/cotato/itda/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,35 @@
+package com.cotato.itda.domain.notification.converter;
+
+import java.util.List;
+
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.entity.Notification;
+
+public class NotificationConverter {
+
+	public static NotificationListResponse.NotificationItem toListItem(Notification notification) {
+		return NotificationListResponse.NotificationItem.builder()
+			.notificationId(notification.getId())
+			.section(notification.getSection())
+			.type(notification.getType())
+			.content(notification.getContent())
+			.imageUrl(notification.getImageUrl())
+			.targetType(notification.getTargetType())
+			.targetId(notification.getTargetId())
+			.isRead(notification.isRead())
+			.createdAt(notification.getCreatedAt())
+			.build();
+	}
+
+	public static NotificationListResponse toListResponse(
+		List<NotificationListResponse.NotificationItem> items,
+		Long lastId,
+		boolean hasNext
+	) {
+		return NotificationListResponse.builder()
+			.notifications(items)
+			.lastId(lastId)
+			.hasNext(hasNext)
+			.build();
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/cotato/itda/domain/notification/dto/NotificationListResponse.java
@@ -1,0 +1,55 @@
+package com.cotato.itda.domain.notification.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record NotificationListResponse(
+	@Schema(description = "알림 목록")
+	List<NotificationItem> notifications,
+
+	@Schema(description = "현재 응답된 목록 중 가장 마지막 알림 ID", example = "10")
+	Long lastId,
+
+	@Schema(description = "다음 알림 존재 여부", example = "true")
+	boolean hasNext
+) {
+
+	@Builder
+	public record NotificationItem(
+		@Schema(description = "알림 ID", example = "1")
+		Long notificationId,
+
+		@Schema(description = "알림 섹션", example = "GARDEN")
+		NotificationSection section,
+
+		@Schema(description = "알림 타입", example = "PLANT_INVITE")
+		NotificationType type,
+
+		@Schema(description = "알림 본문", example = "이속희님이 초대장을 보냈어요.")
+		String content,
+
+		@Schema(description = "프로필 또는 대상 이미지 URL", example = "https://example.com/profile.jpg")
+		String imageUrl,
+
+		@Schema(description = "이동 대상 타입", example = "SHARED_PLANT_INVITE")
+		NotificationTargetType targetType,
+
+		@Schema(description = "이동 대상 ID", example = "10")
+		Long targetId,
+
+		@Schema(description = "읽음 여부", example = "false")
+		boolean isRead,
+
+		@Schema(description = "알림 생성 시각", example = "2026-06-14T12:00:00")
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/dto/UnreadNotificationCountResponse.java
+++ b/src/main/java/com/cotato/itda/domain/notification/dto/UnreadNotificationCountResponse.java
@@ -1,0 +1,11 @@
+package com.cotato.itda.domain.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record UnreadNotificationCountResponse(
+	@Schema(description = "읽지 않은 알림 개수", example = "3")
+	long count
+) {
+}

--- a/src/main/java/com/cotato/itda/domain/notification/entity/Notification.java
+++ b/src/main/java/com/cotato/itda/domain/notification/entity/Notification.java
@@ -1,0 +1,83 @@
+package com.cotato.itda.domain.notification.entity;
+
+import java.time.LocalDateTime;
+
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
+import com.cotato.itda.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+	name = "notifications",
+	indexes = {
+		@Index(name = "idx_notifications_receiver_id", columnList = "receiver_id, id"),
+		@Index(name = "idx_notifications_receiver_read", columnList = "receiver_id, is_read")
+	}
+)
+public class Notification extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "receiver_id", nullable = false)
+	private Member receiver;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "section", nullable = false, length = 30)
+	private NotificationSection section;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 50)
+	private NotificationType type;
+
+	@Column(name = "content", nullable = false, length = 255)
+	private String content;
+
+	@Column(name = "image_url", length = 500)
+	private String imageUrl;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "target_type", length = 50)
+	private NotificationTargetType targetType;
+
+	@Column(name = "target_id")
+	private Long targetId;
+
+	@Builder.Default
+	@Column(name = "is_read", nullable = false)
+	private boolean read = false;
+
+	@Column(name = "read_at")
+	private LocalDateTime readAt;
+
+	public boolean isOwnedBy(Long memberId) {
+		return receiver != null && memberId != null && memberId.equals(receiver.getId());
+	}
+
+	public void markAsRead(LocalDateTime readAt) {
+		if (read) {
+			return;
+		}
+		this.read = true;
+		this.readAt = readAt;
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/enums/NotificationSection.java
+++ b/src/main/java/com/cotato/itda/domain/notification/enums/NotificationSection.java
@@ -1,0 +1,6 @@
+package com.cotato.itda.domain.notification.enums;
+
+public enum NotificationSection {
+	GARDEN,
+	DAILY_RECORD
+}

--- a/src/main/java/com/cotato/itda/domain/notification/enums/NotificationTargetType.java
+++ b/src/main/java/com/cotato/itda/domain/notification/enums/NotificationTargetType.java
@@ -1,0 +1,8 @@
+package com.cotato.itda.domain.notification.enums;
+
+public enum NotificationTargetType {
+	SHARED_PLANT_INVITE,
+	SHARED_PLANT,
+	CHALLENGE,
+	DIARY
+}

--- a/src/main/java/com/cotato/itda/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/cotato/itda/domain/notification/enums/NotificationType.java
@@ -1,0 +1,11 @@
+package com.cotato.itda.domain.notification.enums;
+
+public enum NotificationType {
+	PLANT_INVITE,
+	PLANT_WATER_NEEDED,
+	PLANT_INVITE_ACCEPTED,
+	CHALLENGE_COMMENT,
+	CHALLENGE_LIKE,
+	DIARY_COMMENT,
+	DIARY_LIKE
+}

--- a/src/main/java/com/cotato/itda/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/cotato/itda/domain/notification/exception/NotificationException.java
@@ -1,0 +1,17 @@
+package com.cotato.itda.domain.notification.exception;
+
+import java.util.Map;
+
+import com.cotato.itda.domain.notification.exception.code.NotificationErrorCode;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+public class NotificationException extends BusinessException {
+
+	public NotificationException(NotificationErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public NotificationException(NotificationErrorCode errorCode, Map<String, Object> reasons) {
+		super(errorCode, reasons);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/notification/exception/code/NotificationErrorCode.java
@@ -1,0 +1,27 @@
+package com.cotato.itda.domain.notification.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.cotato.itda.global.error.constant.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+	NOTIFICATION_NOT_FOUND(
+		HttpStatus.NOT_FOUND,
+		"해당 알림을 찾을 수 없습니다.",
+		"NOTIFICATION_ERROR_404_NOTIFICATION_NOT_FOUND"
+	),
+	NOTIFICATION_FORBIDDEN(
+		HttpStatus.FORBIDDEN,
+		"해당 알림에 대한 권한이 없습니다.",
+		"NOTIFICATION_ERROR_403_NOTIFICATION_FORBIDDEN"
+	);
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/cotato/itda/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/cotato/itda/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,31 @@
+package com.cotato.itda.domain.notification.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.cotato.itda.domain.notification.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findByReceiverIdOrderByIdDesc(Long receiverId, Pageable pageable);
+
+	List<Notification> findByReceiverIdAndIdLessThanOrderByIdDesc(Long receiverId, Long lastId, Pageable pageable);
+
+	long countByReceiverIdAndReadFalse(Long receiverId);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		update Notification n
+		set n.read = true,
+			n.readAt = :readAt
+		where n.receiver.id = :receiverId
+			and n.read = false
+		""")
+	int markAllAsReadByReceiverId(@Param("receiverId") Long receiverId, @Param("readAt") LocalDateTime readAt);
+}

--- a/src/main/java/com/cotato/itda/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/NotificationService.java
@@ -1,0 +1,67 @@
+package com.cotato.itda.domain.notification.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.notification.converter.NotificationConverter;
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
+import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.exception.NotificationException;
+import com.cotato.itda.domain.notification.exception.code.NotificationErrorCode;
+import com.cotato.itda.domain.notification.repository.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+
+	@Transactional(readOnly = true)
+	public NotificationListResponse getNotifications(Long memberId, Long lastId, int limit) {
+		PageRequest pageRequest = PageRequest.of(0, limit + 1);
+		List<Notification> fetched = lastId == null
+			? notificationRepository.findByReceiverIdOrderByIdDesc(memberId, pageRequest)
+			: notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(memberId, lastId, pageRequest);
+
+		boolean hasNext = fetched.size() > limit;
+		List<Notification> page = hasNext ? fetched.subList(0, limit) : fetched;
+		Long nextLastId = page.isEmpty() ? null : page.get(page.size() - 1).getId();
+
+		List<NotificationListResponse.NotificationItem> items = page.stream()
+			.map(NotificationConverter::toListItem)
+			.toList();
+
+		return NotificationConverter.toListResponse(items, nextLastId, hasNext);
+	}
+
+	@Transactional(readOnly = true)
+	public UnreadNotificationCountResponse getUnreadCount(Long memberId) {
+		return UnreadNotificationCountResponse.builder()
+			.count(notificationRepository.countByReceiverIdAndReadFalse(memberId))
+			.build();
+	}
+
+	@Transactional
+	public void markAsRead(Long memberId, Long notificationId) {
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+		if (!notification.isOwnedBy(memberId)) {
+			throw new NotificationException(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
+		}
+
+		notification.markAsRead(LocalDateTime.now());
+	}
+
+	@Transactional
+	public void markAllAsRead(Long memberId) {
+		notificationRepository.markAllAsReadByReceiverId(memberId, LocalDateTime.now());
+	}
+}

--- a/src/main/java/com/cotato/itda/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/itda/global/error/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.error.constant.GlobalErrorCode;
@@ -102,6 +104,63 @@ public class GlobalExceptionHandler {
 		);
 
 		// 10. HTTP 상태 코드와 에러 바디를 담은 ResponseEntity를 최종 반환한다.
+		return ResponseEntity
+			.status(GlobalErrorCode.VALIDATION_ERROR.getHttpStatus())
+			.body(body);
+	}
+
+	/**
+	 * 메서드 파라미터 Bean Validation 실패 – @RequestParam, @PathVariable 등에 붙은
+	 * @Min, @Max, @NotNull 같은 제약 조건 위반을 처리한다.
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(
+		ConstraintViolationException ex,
+		HttpServletRequest request
+	) {
+		Map<String, Object> reasons = new HashMap<>();
+		ex.getConstraintViolations().forEach(violation ->
+			reasons.put(violation.getPropertyPath().toString(), violation.getMessage())
+		);
+
+		log.warn("[Validation] path={}, reasons={}", request.getRequestURI(), reasons);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.VALIDATION_ERROR,
+			request.getRequestURI(),
+			reasons
+		);
+
+		return ResponseEntity
+			.status(GlobalErrorCode.VALIDATION_ERROR.getHttpStatus())
+			.body(body);
+	}
+
+	/**
+	 * Spring MVC 메서드 검증 실패 – Spring 6에서 컨트롤러 메서드 파라미터 검증 실패 시
+	 * 발생할 수 있는 예외를 공통 Validation 응답으로 변환한다.
+	 */
+	@ExceptionHandler(HandlerMethodValidationException.class)
+	public ResponseEntity<ApiResponse<Void>> handleHandlerMethodValidationException(
+		HandlerMethodValidationException ex,
+		HttpServletRequest request
+	) {
+		Map<String, Object> reasons = new HashMap<>();
+		ex.getAllErrors().forEach(error -> {
+			String key = error.getCodes() != null && error.getCodes().length > 0
+				? error.getCodes()[0]
+				: "validation";
+			reasons.put(key, error.getDefaultMessage());
+		});
+
+		log.warn("[Validation] path={}, reasons={}", request.getRequestURI(), reasons);
+
+		ApiResponse<Void> body = ApiResponse.error(
+			GlobalErrorCode.VALIDATION_ERROR,
+			request.getRequestURI(),
+			reasons
+		);
+
 		return ResponseEntity
 			.status(GlobalErrorCode.VALIDATION_ERROR.getHttpStatus())
 			.body(body);

--- a/src/test/java/com/cotato/itda/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/cotato/itda/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,160 @@
+package com.cotato.itda.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
+import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
+import com.cotato.itda.domain.notification.exception.code.NotificationErrorCode;
+import com.cotato.itda.domain.notification.repository.NotificationRepository;
+import com.cotato.itda.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationService notificationService;
+
+	@Test
+	void getNotifications_returns_my_notifications_with_cursor_metadata() {
+		Notification first = notification(3L, 1L, false);
+		Notification second = notification(2L, 1L, true);
+		Notification extra = notification(1L, 1L, false);
+
+		when(notificationRepository.findByReceiverIdOrderByIdDesc(any(), any()))
+			.thenReturn(List.of(first, second, extra));
+
+		NotificationListResponse response = notificationService.getNotifications(1L, null, 2);
+
+		assertThat(response.notifications()).hasSize(2);
+		assertThat(response.notifications().get(0).notificationId()).isEqualTo(3L);
+		assertThat(response.notifications().get(0).section()).isEqualTo(NotificationSection.GARDEN);
+		assertThat(response.notifications().get(0).type()).isEqualTo(NotificationType.PLANT_INVITE);
+		assertThat(response.lastId()).isEqualTo(2L);
+		assertThat(response.hasNext()).isTrue();
+
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(notificationRepository).findByReceiverIdOrderByIdDesc(any(), pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(3);
+	}
+
+	@Test
+	void getNotifications_uses_last_id_cursor_when_present() {
+		when(notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any()))
+			.thenReturn(List.of(notification(9L, 1L, false)));
+
+		NotificationListResponse response = notificationService.getNotifications(1L, 10L, 20);
+
+		assertThat(response.notifications()).hasSize(1);
+		assertThat(response.lastId()).isEqualTo(9L);
+		assertThat(response.hasNext()).isFalse();
+		verify(notificationRepository).findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any());
+	}
+
+	@Test
+	void getUnreadCount_counts_only_my_unread_notifications() {
+		when(notificationRepository.countByReceiverIdAndReadFalse(1L)).thenReturn(3L);
+
+		UnreadNotificationCountResponse response = notificationService.getUnreadCount(1L);
+
+		assertThat(response.count()).isEqualTo(3L);
+	}
+
+	@Test
+	void markAsRead_marks_my_notification_as_read() {
+		Notification notification = notification(1L, 1L, false);
+		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
+
+		notificationService.markAsRead(1L, 1L);
+
+		assertThat(notification.isRead()).isTrue();
+		assertThat(notification.getReadAt()).isNotNull();
+	}
+
+	@Test
+	void markAsRead_keeps_already_read_notification_successful() {
+		Notification notification = notification(1L, 1L, true);
+		LocalDateTime readAt = LocalDateTime.of(2026, 6, 14, 12, 0);
+		ReflectionTestUtils.setField(notification, "readAt", readAt);
+		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
+
+		notificationService.markAsRead(1L, 1L);
+
+		assertThat(notification.isRead()).isTrue();
+		assertThat(notification.getReadAt()).isEqualTo(readAt);
+	}
+
+	@Test
+	void markAsRead_rejects_other_members_notification() {
+		Notification notification = notification(1L, 2L, false);
+		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
+
+		assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
+
+		assertThat(notification.isRead()).isFalse();
+	}
+
+	@Test
+	void markAsRead_rejects_missing_notification() {
+		when(notificationRepository.findById(1L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+	}
+
+	@Test
+	void markAllAsRead_updates_only_my_unread_notifications() {
+		notificationService.markAllAsRead(1L);
+
+		verify(notificationRepository).markAllAsReadByReceiverId(any(), any());
+	}
+
+	private Notification notification(Long notificationId, Long receiverId, boolean isRead) {
+		Member receiver = Member.builder().build();
+		ReflectionTestUtils.setField(receiver, "id", receiverId);
+
+		Notification notification = Notification.builder()
+			.receiver(receiver)
+			.section(NotificationSection.GARDEN)
+			.type(NotificationType.PLANT_INVITE)
+			.content("초대장이 도착했어요.")
+			.imageUrl("https://example.com/profile.jpg")
+			.targetType(NotificationTargetType.SHARED_PLANT_INVITE)
+			.targetId(10L)
+			.read(isRead)
+			.build();
+
+		ReflectionTestUtils.setField(notification, "id", notificationId);
+		ReflectionTestUtils.setField(notification, "createdAt", LocalDateTime.of(2026, 6, 14, 12, 0));
+		return notification;
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143

## 📝작업 내용

- 인앱 알림을 저장하고 조회할 수 있는 기본 API를 추가했습니다. 알림은 사용자별로 최신순 조회하며, 미읽음 개수 조회와 단건/전체 읽음 처리를 지원합니다.

- 이번 작업은 알림 도메인의 기반 구현이며, 댓글/좋아요/초대장 등 기존 도메인 API에서 알림을 생성하는 연동은 후속 작업으로 분리합니다.

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

없음

## 📌참고 사항

- 알림 목록 조회는 `receiver_id, id` 기준 커서 페이지네이션으로 동작합니다.
- `targetType`, `targetId`는 프론트에서 화면 이동 경로로 매핑하는 전제입니다.

## 💬리뷰 요구사항 

- 알림 엔티티의 필드 구성이 현재 인앱 알림 요구사항에 적절한지 확인 부탁드립니다.
- 알림 조회 및 읽음 처리 과정에서 추가로 고려해야 할 예외 상황이 있는지 확인 부탁드립니다.
