### PR TITLE
[feat] 이벤트 기반 인앱 알림 적재 구현

### DIFF
--- a/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommentCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeCommentCommandService.java
@@ -10,6 +10,7 @@ import com.cotato.itda.domain.challenge.repository.ChallengeRepository;
 import com.cotato.itda.domain.challenge.service.validator.ChallengeAccessValidator;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
 import com.cotato.itda.domain.challenge.exception.code.ChallengeErrorCode;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
@@ -28,6 +29,7 @@ public class ChallengeCommentCommandService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeCommentRepository challengeCommentRepository;
     private final ChallengeAccessValidator challengeAccessValidator;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public ChallengeCommentResponse createComment(Long memberId, Long challengeId, ChallengeCommentRequest request) {
@@ -58,6 +60,7 @@ public class ChallengeCommentCommandService {
 
         ChallengeComment savedComment = challengeCommentRepository.save(comment);
         challenge.increaseComment();
+        notificationCommandService.createChallengeCommentNotification(member, challenge);
 
         return ChallengeCommentConverter.toResponse(savedComment, member);
     }

--- a/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeLikeCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/challenge/service/command/ChallengeLikeCommandService.java
@@ -8,6 +8,7 @@ import com.cotato.itda.domain.challenge.repository.ChallengeRepository;
 import com.cotato.itda.domain.challenge.service.validator.ChallengeAccessValidator;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
 import com.cotato.itda.domain.challenge.exception.code.ChallengeErrorCode;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
@@ -26,6 +27,7 @@ public class ChallengeLikeCommandService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeLikeRepository challengeLikeRepository;
     private final ChallengeAccessValidator challengeAccessValidator;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public ChallengeLikeResponse addLike(Long memberId, Long challengeId) {
@@ -49,6 +51,7 @@ public class ChallengeLikeCommandService {
 
         challengeLikeRepository.save(like);
         challenge.increaseLike();
+        notificationCommandService.createChallengeLikeNotification(member, challenge);
 
         return new ChallengeLikeResponse(challenge.getLikeCount());
     }

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommentCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryCommentCommandService.java
@@ -11,6 +11,7 @@ import com.cotato.itda.domain.diary.repository.DiaryRepository;
 import com.cotato.itda.domain.diary.validator.DiaryAccessValidator;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
 import com.cotato.itda.domain.diary.exception.code.DiaryErrorCode;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
@@ -29,6 +30,7 @@ public class DiaryCommentCommandService {
     private final DiaryRepository diaryRepository;
     private final DiaryCommentRepository diaryCommentRepository;
     private final DiaryAccessValidator diaryAccessValidator;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public DiaryCommentResponse createComment(Long memberId, Long diaryId, DiaryCommentRequest request) {
@@ -53,6 +55,7 @@ public class DiaryCommentCommandService {
         DiaryComment savedComment = diaryCommentRepository.save(comment);
 
         diary.increaseComment();
+        notificationCommandService.createDiaryCommentNotification(member, diary);
 
         // 작성자 정보 생성
         WriterInfo writerInfo = DiaryCommentConverter.toWriterInfo(member, member.getName(), true);

--- a/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryLikeCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/diary/service/command/DiaryLikeCommandService.java
@@ -8,6 +8,7 @@ import com.cotato.itda.domain.diary.repository.DiaryRepository;
 import com.cotato.itda.domain.diary.validator.DiaryAccessValidator;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
 import com.cotato.itda.domain.diary.exception.code.DiaryErrorCode;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
@@ -26,6 +27,7 @@ public class DiaryLikeCommandService {
     private final DiaryRepository diaryRepository;
     private final DiaryLikeRepository diaryLikeRepository;
     private final DiaryAccessValidator diaryAccessValidator;
+    private final NotificationCommandService notificationCommandService;
 
     @Transactional
     public DiaryLikeResponse addLike(Long memberId, Long diaryId) {
@@ -50,6 +52,7 @@ public class DiaryLikeCommandService {
 
         diaryLikeRepository.save(like);
         diary.increaseLike();
+        notificationCommandService.createDiaryLikeNotification(member, diary);
 
         return new DiaryLikeResponse(diary.getLikeCount());
     }

--- a/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
+++ b/src/main/java/com/cotato/itda/domain/garden/repository/SharedPlantRepository.java
@@ -29,6 +29,13 @@ public interface SharedPlantRepository extends JpaRepository<SharedPlant, Long> 
     List<SharedPlant> findAllByStatusAndIsPlantedTrue(SharedPlantStatus status);
 
     @Query("SELECT sp FROM SharedPlant sp " +
+            "JOIN FETCH sp.memberA " +
+            "JOIN FETCH sp.memberB " +
+            "WHERE sp.status = :status " +
+            "AND sp.isPlanted = true")
+    List<SharedPlant> findAllByStatusAndIsPlantedTrueWithMembers(@Param("status") SharedPlantStatus status);
+
+    @Query("SELECT sp FROM SharedPlant sp " +
             "WHERE (sp.memberA.id = :memberId OR sp.memberB.id = :memberId) " +
             "AND sp.status = com.cotato.itda.domain.garden.enums.SharedPlantStatus.GROWING " +
             "AND sp.isPlanted = true " +

--- a/src/main/java/com/cotato/itda/domain/garden/scheduler/PlantWaterNeededNotificationScheduler.java
+++ b/src/main/java/com/cotato/itda/domain/garden/scheduler/PlantWaterNeededNotificationScheduler.java
@@ -1,0 +1,49 @@
+package com.cotato.itda.domain.garden.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.enums.SharedPlantStatus;
+import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PlantWaterNeededNotificationScheduler {
+
+	private final SharedPlantRepository sharedPlantRepository;
+	private final NotificationCommandService notificationCommandService;
+
+	// 물주기 가능 시점부터 시듦까지 여유가 있어 hourly polling으로 충분하다.
+	@Scheduled(cron = "0 0 * * * *")
+	@Transactional
+	public void sendWaterNeededNotifications() {
+		List<SharedPlant> plants = sharedPlantRepository
+			.findAllByStatusAndIsPlantedTrueWithMembers(SharedPlantStatus.GROWING);
+
+		for (SharedPlant plant : plants) {
+			notifyWaterNeeded(plant);
+		}
+	}
+
+	private void notifyWaterNeeded(SharedPlant plant) {
+		Long lastWateredBy = plant.getLastWateredBy();
+
+		if (lastWateredBy == null) {
+			return;
+		}
+
+		Member receiver = lastWateredBy.equals(plant.getMemberA().getId())
+			? plant.getMemberB()
+			: plant.getMemberA();
+
+		notificationCommandService.createPlantWaterNeededNotification(receiver, plant);
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/garden/service/command/SharedPlantInviteCommandServiceImpl.java
@@ -22,6 +22,7 @@ import com.cotato.itda.domain.garden.repository.SharedPlantInviteRepository;
 import com.cotato.itda.domain.garden.repository.SharedPlantRepository;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
 import com.cotato.itda.global.error.constant.UserErrorCode;
 import com.cotato.itda.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
     private final FriendshipRepository friendshipRepository;
     private final SharedPlantRepository sharedPlantRepository;
     private final SharedPlantInviteRepository sharedPlantInviteRepository;
+    private final NotificationCommandService notificationCommandService;
 
     @Override
     public PlantInviteResDTO.CreateSharedPlantInviteResDTO createInvite(Long inviterId,
@@ -86,6 +88,7 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
                 .build();
 
         SharedPlantInvite savedInvite = sharedPlantInviteRepository.save(invite);
+        notificationCommandService.createPlantInviteNotification(inviter, savedInvite);
 
         return SharedPlantInviteConverter.toCreateSharedPlantInviteResDTO(savedInvite);
     }
@@ -133,6 +136,9 @@ public class SharedPlantInviteCommandServiceImpl implements SharedPlantInviteCom
         }
 
         invite.updateStatus(dto.status());
+        if (sharedPlant != null) {
+            notificationCommandService.createPlantInviteAcceptedNotification(invite.getInvitee(), invite, sharedPlant);
+        }
 
         return SharedPlantInviteConverter.toUpdateSharedPlantInviteResDTO(invite, sharedPlant);
     }

--- a/src/main/java/com/cotato/itda/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/cotato/itda/domain/notification/controller/NotificationController.java
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.cotato.itda.domain.notification.dto.NotificationListResponse;
 import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
-import com.cotato.itda.domain.notification.service.NotificationService;
+import com.cotato.itda.domain.notification.service.command.NotificationCommandService;
+import com.cotato.itda.domain.notification.service.query.NotificationQueryService;
 import com.cotato.itda.global.common.response.ApiResponse;
 import com.cotato.itda.global.security.jwt.principal.JwtPrincipal;
 
@@ -29,7 +30,8 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Notification", description = "인앱 알림 API")
 public class NotificationController {
 
-	private final NotificationService notificationService;
+	private final NotificationQueryService notificationQueryService;
+	private final NotificationCommandService notificationCommandService;
 
 	@Operation(
 		summary = "내 알림 목록 조회",
@@ -57,7 +59,7 @@ public class NotificationController {
 		@Max(value = 50, message = "limit은 50 이하이어야 합니다.")
 		int limit
 	) {
-		NotificationListResponse response = notificationService.getNotifications(jwtPrincipal.memberId(), lastId, limit);
+		NotificationListResponse response = notificationQueryService.getNotifications(jwtPrincipal.memberId(), lastId, limit);
 		return ApiResponse.success(response);
 	}
 
@@ -67,7 +69,7 @@ public class NotificationController {
 	public ApiResponse<UnreadNotificationCountResponse> getUnreadCount(
 		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal
 	) {
-		UnreadNotificationCountResponse response = notificationService.getUnreadCount(jwtPrincipal.memberId());
+		UnreadNotificationCountResponse response = notificationQueryService.getUnreadCount(jwtPrincipal.memberId());
 		return ApiResponse.success(response);
 	}
 
@@ -84,7 +86,7 @@ public class NotificationController {
 		@Parameter(description = "읽음 처리할 알림 ID", required = true, example = "1")
 		@PathVariable Long notificationId
 	) {
-		notificationService.markAsRead(jwtPrincipal.memberId(), notificationId);
+		notificationCommandService.markAsRead(jwtPrincipal.memberId(), notificationId);
 		return ApiResponse.success(null);
 	}
 
@@ -94,7 +96,7 @@ public class NotificationController {
 	public ApiResponse<Void> markAllAsRead(
 		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal jwtPrincipal
 	) {
-		notificationService.markAllAsRead(jwtPrincipal.memberId());
+		notificationCommandService.markAllAsRead(jwtPrincipal.memberId());
 		return ApiResponse.success(null);
 	}
 }

--- a/src/main/java/com/cotato/itda/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/cotato/itda/domain/notification/converter/NotificationConverter.java
@@ -2,10 +2,34 @@ package com.cotato.itda.domain.notification.converter;
 
 import java.util.List;
 
+import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.notification.dto.NotificationListResponse;
 import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
 
 public class NotificationConverter {
+
+	public static Notification toNotification(
+		Member receiver,
+		NotificationSection section,
+		NotificationType type,
+		String content,
+		String imageUrl,
+		NotificationTargetType targetType,
+		Long targetId
+	) {
+		return Notification.builder()
+			.receiver(receiver)
+			.section(section)
+			.type(type)
+			.content(content)
+			.imageUrl(imageUrl)
+			.targetType(targetType)
+			.targetId(targetId)
+			.build();
+	}
 
 	public static NotificationListResponse.NotificationItem toListItem(Notification notification) {
 		return NotificationListResponse.NotificationItem.builder()

--- a/src/main/java/com/cotato/itda/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/cotato/itda/domain/notification/repository/NotificationRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -18,6 +20,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	List<Notification> findByReceiverIdAndIdLessThanOrderByIdDesc(Long receiverId, Long lastId, Pageable pageable);
 
 	long countByReceiverIdAndReadFalse(Long receiverId);
+
+	boolean existsByReceiverIdAndTypeAndTargetTypeAndTargetIdAndCreatedAtAfter(
+		Long receiverId,
+		NotificationType type,
+		NotificationTargetType targetType,
+		Long targetId,
+		LocalDateTime createdAt
+	);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("""

--- a/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandService.java
@@ -1,0 +1,28 @@
+package com.cotato.itda.domain.notification.service.command;
+
+import com.cotato.itda.domain.challenge.entity.Challenge;
+import com.cotato.itda.domain.diary.entity.Diary;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.member.entity.Member;
+
+public interface NotificationCommandService {
+
+	void markAsRead(Long memberId, Long notificationId);
+
+	void markAllAsRead(Long memberId);
+
+	void createChallengeCommentNotification(Member actor, Challenge challenge);
+
+	void createChallengeLikeNotification(Member actor, Challenge challenge);
+
+	void createDiaryCommentNotification(Member actor, Diary diary);
+
+	void createDiaryLikeNotification(Member actor, Diary diary);
+
+	void createPlantInviteNotification(Member actor, SharedPlantInvite invite);
+
+	void createPlantInviteAcceptedNotification(Member actor, SharedPlantInvite invite, SharedPlant sharedPlant);
+
+	void createPlantWaterNeededNotification(Member receiver, SharedPlant sharedPlant);
+}

--- a/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -1,0 +1,197 @@
+package com.cotato.itda.domain.notification.service.command;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.itda.domain.challenge.entity.Challenge;
+import com.cotato.itda.domain.diary.entity.Diary;
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.notification.converter.NotificationConverter;
+import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
+import com.cotato.itda.domain.notification.exception.NotificationException;
+import com.cotato.itda.domain.notification.exception.code.NotificationErrorCode;
+import com.cotato.itda.domain.notification.repository.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+
+	private final NotificationRepository notificationRepository;
+
+	@Override
+	public void markAsRead(Long memberId, Long notificationId) {
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+		if (!notification.isOwnedBy(memberId)) {
+			throw new NotificationException(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
+		}
+
+		notification.markAsRead(LocalDateTime.now());
+	}
+
+	@Override
+	public void markAllAsRead(Long memberId) {
+		notificationRepository.markAllAsReadByReceiverId(memberId, LocalDateTime.now());
+	}
+
+	@Override
+	public void createChallengeCommentNotification(Member actor, Challenge challenge) {
+		createIfNotSelf(
+			actor,
+			challenge.getMember(),
+			NotificationSection.DAILY_RECORD,
+			NotificationType.CHALLENGE_COMMENT,
+			actor.getName() + "님이 하루 한컷에 댓글을 남겼어요.",
+			challenge.getImageUrl(),
+			NotificationTargetType.CHALLENGE,
+			challenge.getId()
+		);
+	}
+
+	@Override
+	public void createChallengeLikeNotification(Member actor, Challenge challenge) {
+		createIfNotSelf(
+			actor,
+			challenge.getMember(),
+			NotificationSection.DAILY_RECORD,
+			NotificationType.CHALLENGE_LIKE,
+			actor.getName() + "님이 하루 한컷을 좋아해요.",
+			challenge.getImageUrl(),
+			NotificationTargetType.CHALLENGE,
+			challenge.getId()
+		);
+	}
+
+	@Override
+	public void createDiaryCommentNotification(Member actor, Diary diary) {
+		createIfNotSelf(
+			actor,
+			diary.getMember(),
+			NotificationSection.DAILY_RECORD,
+			NotificationType.DIARY_COMMENT,
+			actor.getName() + "님이 공유일기에 댓글을 남겼어요.",
+			diary.getImageUrl(),
+			NotificationTargetType.DIARY,
+			diary.getId()
+		);
+	}
+
+	@Override
+	public void createDiaryLikeNotification(Member actor, Diary diary) {
+		createIfNotSelf(
+			actor,
+			diary.getMember(),
+			NotificationSection.DAILY_RECORD,
+			NotificationType.DIARY_LIKE,
+			actor.getName() + "님이 공유일기를 좋아해요.",
+			diary.getImageUrl(),
+			NotificationTargetType.DIARY,
+			diary.getId()
+		);
+	}
+
+	@Override
+	public void createPlantInviteNotification(Member actor, SharedPlantInvite invite) {
+		createIfNotSelf(
+			actor,
+			invite.getInvitee(),
+			NotificationSection.GARDEN,
+			NotificationType.PLANT_INVITE,
+			actor.getName() + "님이 초대장을 보냈어요.",
+			null,
+			NotificationTargetType.SHARED_PLANT_INVITE,
+			invite.getId()
+		);
+	}
+
+	@Override
+	public void createPlantInviteAcceptedNotification(Member actor, SharedPlantInvite invite, SharedPlant sharedPlant) {
+		createIfNotSelf(
+			actor,
+			invite.getInviter(),
+			NotificationSection.GARDEN,
+			NotificationType.PLANT_INVITE_ACCEPTED,
+			actor.getName() + "님이 초대장을 수락했어요.",
+			null,
+			NotificationTargetType.SHARED_PLANT,
+			sharedPlant.getId()
+		);
+	}
+
+	@Override
+	public void createPlantWaterNeededNotification(Member receiver, SharedPlant sharedPlant) {
+		if (sharedPlant.getLastWateredAt() == null
+			|| LocalDateTime.now().isBefore(sharedPlant.getLastWateredAt().plusHours(24))
+			|| alreadySentAfterLastWatering(receiver, sharedPlant)) {
+			return;
+		}
+
+		create(
+			receiver,
+			NotificationSection.GARDEN,
+			NotificationType.PLANT_WATER_NEEDED,
+			sharedPlant.getNickname() + "에 물이 필요해요.",
+			null,
+			NotificationTargetType.SHARED_PLANT,
+			sharedPlant.getId()
+		);
+	}
+
+	private boolean alreadySentAfterLastWatering(Member receiver, SharedPlant sharedPlant) {
+		return notificationRepository.existsByReceiverIdAndTypeAndTargetTypeAndTargetIdAndCreatedAtAfter(
+			receiver.getId(),
+			NotificationType.PLANT_WATER_NEEDED,
+			NotificationTargetType.SHARED_PLANT,
+			sharedPlant.getId(),
+			sharedPlant.getLastWateredAt()
+		);
+	}
+
+	private void createIfNotSelf(
+		Member actor,
+		Member receiver,
+		NotificationSection section,
+		NotificationType type,
+		String content,
+		String imageUrl,
+		NotificationTargetType targetType,
+		Long targetId
+	) {
+		if (actor.getId().equals(receiver.getId())) {
+			return;
+		}
+
+		create(receiver, section, type, content, imageUrl, targetType, targetId);
+	}
+
+	private void create(
+		Member receiver,
+		NotificationSection section,
+		NotificationType type,
+		String content,
+		String imageUrl,
+		NotificationTargetType targetType,
+		Long targetId
+	) {
+		notificationRepository.save(NotificationConverter.toNotification(
+			receiver,
+			section,
+			type,
+			content,
+			imageUrl,
+			targetType,
+			targetId
+		));
+	}
+}

--- a/src/main/java/com/cotato/itda/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/query/NotificationQueryService.java
@@ -1,0 +1,11 @@
+package com.cotato.itda.domain.notification.service.query;
+
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
+
+public interface NotificationQueryService {
+
+	NotificationListResponse getNotifications(Long memberId, Long lastId, int limit);
+
+	UnreadNotificationCountResponse getUnreadCount(Long memberId);
+}

--- a/src/main/java/com/cotato/itda/domain/notification/service/query/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/query/NotificationQueryServiceImpl.java
@@ -1,6 +1,5 @@
-package com.cotato.itda.domain.notification.service;
+package com.cotato.itda.domain.notification.service.query;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -11,19 +10,18 @@ import com.cotato.itda.domain.notification.converter.NotificationConverter;
 import com.cotato.itda.domain.notification.dto.NotificationListResponse;
 import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
 import com.cotato.itda.domain.notification.entity.Notification;
-import com.cotato.itda.domain.notification.exception.NotificationException;
-import com.cotato.itda.domain.notification.exception.code.NotificationErrorCode;
 import com.cotato.itda.domain.notification.repository.NotificationRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationService {
+@Transactional(readOnly = true)
+public class NotificationQueryServiceImpl implements NotificationQueryService {
 
 	private final NotificationRepository notificationRepository;
 
-	@Transactional(readOnly = true)
+	@Override
 	public NotificationListResponse getNotifications(Long memberId, Long lastId, int limit) {
 		PageRequest pageRequest = PageRequest.of(0, limit + 1);
 		List<Notification> fetched = lastId == null
@@ -41,27 +39,10 @@ public class NotificationService {
 		return NotificationConverter.toListResponse(items, nextLastId, hasNext);
 	}
 
-	@Transactional(readOnly = true)
+	@Override
 	public UnreadNotificationCountResponse getUnreadCount(Long memberId) {
 		return UnreadNotificationCountResponse.builder()
 			.count(notificationRepository.countByReceiverIdAndReadFalse(memberId))
 			.build();
-	}
-
-	@Transactional
-	public void markAsRead(Long memberId, Long notificationId) {
-		Notification notification = notificationRepository.findById(notificationId)
-			.orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
-
-		if (!notification.isOwnedBy(memberId)) {
-			throw new NotificationException(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
-		}
-
-		notification.markAsRead(LocalDateTime.now());
-	}
-
-	@Transactional
-	public void markAllAsRead(Long memberId) {
-		notificationRepository.markAllAsReadByReceiverId(memberId, LocalDateTime.now());
 	}
 }

--- a/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
+++ b/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.cotato.itda.domain.notification.service;
+package com.cotato.itda.domain.notification.service.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -7,21 +7,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.cotato.itda.domain.member.entity.Member;
-import com.cotato.itda.domain.notification.dto.NotificationListResponse;
-import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
 import com.cotato.itda.domain.notification.entity.Notification;
 import com.cotato.itda.domain.notification.enums.NotificationSection;
 import com.cotato.itda.domain.notification.enums.NotificationTargetType;
@@ -31,65 +26,20 @@ import com.cotato.itda.domain.notification.repository.NotificationRepository;
 import com.cotato.itda.global.error.exception.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
-class NotificationServiceTest {
+class NotificationCommandServiceImplTest {
 
 	@Mock
 	private NotificationRepository notificationRepository;
 
 	@InjectMocks
-	private NotificationService notificationService;
-
-	@Test
-	void getNotifications_returns_my_notifications_with_cursor_metadata() {
-		Notification first = notification(3L, 1L, false);
-		Notification second = notification(2L, 1L, true);
-		Notification extra = notification(1L, 1L, false);
-
-		when(notificationRepository.findByReceiverIdOrderByIdDesc(any(), any()))
-			.thenReturn(List.of(first, second, extra));
-
-		NotificationListResponse response = notificationService.getNotifications(1L, null, 2);
-
-		assertThat(response.notifications()).hasSize(2);
-		assertThat(response.notifications().get(0).notificationId()).isEqualTo(3L);
-		assertThat(response.notifications().get(0).section()).isEqualTo(NotificationSection.GARDEN);
-		assertThat(response.notifications().get(0).type()).isEqualTo(NotificationType.PLANT_INVITE);
-		assertThat(response.lastId()).isEqualTo(2L);
-		assertThat(response.hasNext()).isTrue();
-
-		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-		verify(notificationRepository).findByReceiverIdOrderByIdDesc(any(), pageableCaptor.capture());
-		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(3);
-	}
-
-	@Test
-	void getNotifications_uses_last_id_cursor_when_present() {
-		when(notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any()))
-			.thenReturn(List.of(notification(9L, 1L, false)));
-
-		NotificationListResponse response = notificationService.getNotifications(1L, 10L, 20);
-
-		assertThat(response.notifications()).hasSize(1);
-		assertThat(response.lastId()).isEqualTo(9L);
-		assertThat(response.hasNext()).isFalse();
-		verify(notificationRepository).findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any());
-	}
-
-	@Test
-	void getUnreadCount_counts_only_my_unread_notifications() {
-		when(notificationRepository.countByReceiverIdAndReadFalse(1L)).thenReturn(3L);
-
-		UnreadNotificationCountResponse response = notificationService.getUnreadCount(1L);
-
-		assertThat(response.count()).isEqualTo(3L);
-	}
+	private NotificationCommandServiceImpl notificationCommandService;
 
 	@Test
 	void markAsRead_marks_my_notification_as_read() {
 		Notification notification = notification(1L, 1L, false);
 		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
 
-		notificationService.markAsRead(1L, 1L);
+		notificationCommandService.markAsRead(1L, 1L);
 
 		assertThat(notification.isRead()).isTrue();
 		assertThat(notification.getReadAt()).isNotNull();
@@ -102,7 +52,7 @@ class NotificationServiceTest {
 		ReflectionTestUtils.setField(notification, "readAt", readAt);
 		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
 
-		notificationService.markAsRead(1L, 1L);
+		notificationCommandService.markAsRead(1L, 1L);
 
 		assertThat(notification.isRead()).isTrue();
 		assertThat(notification.getReadAt()).isEqualTo(readAt);
@@ -113,7 +63,7 @@ class NotificationServiceTest {
 		Notification notification = notification(1L, 2L, false);
 		when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
 
-		assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+		assertThatThrownBy(() -> notificationCommandService.markAsRead(1L, 1L))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
@@ -125,7 +75,7 @@ class NotificationServiceTest {
 	void markAsRead_rejects_missing_notification() {
 		when(notificationRepository.findById(1L)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+		assertThatThrownBy(() -> notificationCommandService.markAsRead(1L, 1L))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
@@ -133,7 +83,7 @@ class NotificationServiceTest {
 
 	@Test
 	void markAllAsRead_updates_only_my_unread_notifications() {
-		notificationService.markAllAsRead(1L);
+		notificationCommandService.markAllAsRead(1L);
 
 		verify(notificationRepository).markAllAsReadByReceiverId(any(), any());
 	}

--- a/src/test/java/com/cotato/itda/domain/notification/service/query/NotificationQueryServiceImplTest.java
+++ b/src/test/java/com/cotato/itda/domain/notification/service/query/NotificationQueryServiceImplTest.java
@@ -1,0 +1,102 @@
+package com.cotato.itda.domain.notification.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.cotato.itda.domain.member.entity.Member;
+import com.cotato.itda.domain.notification.dto.NotificationListResponse;
+import com.cotato.itda.domain.notification.dto.UnreadNotificationCountResponse;
+import com.cotato.itda.domain.notification.entity.Notification;
+import com.cotato.itda.domain.notification.enums.NotificationSection;
+import com.cotato.itda.domain.notification.enums.NotificationTargetType;
+import com.cotato.itda.domain.notification.enums.NotificationType;
+import com.cotato.itda.domain.notification.repository.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationQueryServiceImplTest {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationQueryServiceImpl notificationQueryService;
+
+	@Test
+	void getNotifications_returns_my_notifications_with_cursor_metadata() {
+		Notification first = notification(3L, 1L, false);
+		Notification second = notification(2L, 1L, true);
+		Notification extra = notification(1L, 1L, false);
+
+		when(notificationRepository.findByReceiverIdOrderByIdDesc(any(), any()))
+			.thenReturn(List.of(first, second, extra));
+
+		NotificationListResponse response = notificationQueryService.getNotifications(1L, null, 2);
+
+		assertThat(response.notifications()).hasSize(2);
+		assertThat(response.notifications().get(0).notificationId()).isEqualTo(3L);
+		assertThat(response.notifications().get(0).section()).isEqualTo(NotificationSection.GARDEN);
+		assertThat(response.notifications().get(0).type()).isEqualTo(NotificationType.PLANT_INVITE);
+		assertThat(response.lastId()).isEqualTo(2L);
+		assertThat(response.hasNext()).isTrue();
+
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(notificationRepository).findByReceiverIdOrderByIdDesc(any(), pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(3);
+	}
+
+	@Test
+	void getNotifications_uses_last_id_cursor_when_present() {
+		when(notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any()))
+			.thenReturn(List.of(notification(9L, 1L, false)));
+
+		NotificationListResponse response = notificationQueryService.getNotifications(1L, 10L, 20);
+
+		assertThat(response.notifications()).hasSize(1);
+		assertThat(response.lastId()).isEqualTo(9L);
+		assertThat(response.hasNext()).isFalse();
+		verify(notificationRepository).findByReceiverIdAndIdLessThanOrderByIdDesc(any(), any(), any());
+	}
+
+	@Test
+	void getUnreadCount_counts_only_my_unread_notifications() {
+		when(notificationRepository.countByReceiverIdAndReadFalse(1L)).thenReturn(3L);
+
+		UnreadNotificationCountResponse response = notificationQueryService.getUnreadCount(1L);
+
+		assertThat(response.count()).isEqualTo(3L);
+	}
+
+	private Notification notification(Long notificationId, Long receiverId, boolean isRead) {
+		Member receiver = Member.builder().build();
+		ReflectionTestUtils.setField(receiver, "id", receiverId);
+
+		Notification notification = Notification.builder()
+			.receiver(receiver)
+			.section(NotificationSection.GARDEN)
+			.type(NotificationType.PLANT_INVITE)
+			.content("초대장이 도착했어요.")
+			.imageUrl("https://example.com/profile.jpg")
+			.targetType(NotificationTargetType.SHARED_PLANT_INVITE)
+			.targetId(10L)
+			.read(isRead)
+			.build();
+
+		ReflectionTestUtils.setField(notification, "id", notificationId);
+		ReflectionTestUtils.setField(notification, "createdAt", LocalDateTime.of(2026, 6, 14, 12, 0));
+		return notification;
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143

## 📝작업 내용

- 댓글, 좋아요, 정원 초대장 등 기존 도메인 이벤트가 발생했을 때 인앱 알림을 적재하도록 연동했습니다.

- 알림 서비스는 기존 도메인 구조에 맞춰 command/query 인터페이스로 분리하고, 알림 엔티티 생성은 converter에서 담당하도록 정리했습니다.

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

없음

## 📌참고 사항

- 하루한컷(challenge), 공유일기(diary), 정원(shared plant invite/water needed) 이벤트에서 알림을 생성합니다.
- 물 필요 알림은 시듦까지 유예 시간이 있어 매시간 polling으로 확인합니다.
- 스케줄러 조회 시 memberA/memberB를 fetch join하여 N+1 가능성을 줄였습니다.

## 💬리뷰 요구사항 

- 알림 문구와 targetType/targetId 매핑이 프론트 화면 이동 요구사항에 맞는지 확인 부탁드립니다.
- 물 필요 알림은 시듦까지 유예 시간이 충분해 실시간 예약 방식 대신 매시간 polling으로 구현했습니다. 이 정도 실시간성이 현재 요구사항에 적절한지 확인 부탁드립니다.
