### PR TITLE
[fix] 알림 Swagger 등록 및 초대 수락자 프로필 이미지 제공

### DIFF
--- a/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/itda/global/config/SwaggerConfig.java
@@ -173,6 +173,16 @@ public class SwaggerConfig {
                 .build();
     }
 
+    @Bean
+    public GroupedOpenApi NotificationApi() {
+        return GroupedOpenApi.builder()
+                .group("Notification")
+                .displayName("Notification API")
+                .packagesToScan("com.cotato.itda.domain.notification.controller")
+                .pathsToMatch("/api/notifications/**")
+                .build();
+    }
+
     // === 공통 에러 응답 자동 추가 (선택) ===
     @Bean
     public OperationCustomizer addGlobalResponses() {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143

## 📝작업 내용

- 알림 컨트롤러에 작성된 Swagger 문서가 Swagger UI의 API 그룹 목록에 노출되도록 `Notification` 그룹을 추가했습니다.
- `PLANT_INVITE_ACCEPTED` 알림 생성 시 초대를 수락한 사용자의 프로필 이미지 URL을 `imageUrl`에 저장하도록 수정했습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [x] 문서 업데이트
- [ ] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

없음

## 📌참고 사항

- Swagger `Notification` 그룹은 `com.cotato.itda.domain.notification.controller` 패키지와 `/api/notifications/**` 경로를 대상으로 구성했습니다.
- 초대 수락 알림의 `imageUrl`에는 알림 생성 시점의 수락자 프로필 이미지 URL이 저장됩니다.

## 💬리뷰 요구사항 

없음