### PR TITLE
[fix] 초대 수락 알림에 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -123,7 +123,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 			NotificationSection.GARDEN,
 			NotificationType.PLANT_INVITE_ACCEPTED,
 			actor.getName() + "님이 초대장을 수락했어요.",
-			null,
+			actor.getProfileImageUrl(),
 			NotificationTargetType.SHARED_PLANT,
 			sharedPlant.getId()
 		);

--- a/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
+++ b/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
@@ -11,11 +11,14 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.cotato.itda.domain.garden.entity.SharedPlant;
+import com.cotato.itda.domain.garden.entity.SharedPlantInvite;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.notification.entity.Notification;
 import com.cotato.itda.domain.notification.enums.NotificationSection;
@@ -88,9 +91,29 @@ class NotificationCommandServiceImplTest {
 		verify(notificationRepository).markAllAsReadByReceiverId(any(), any());
 	}
 
+	@Test
+	void createPlantInviteAcceptedNotification_uses_actor_profile_image() {
+		Member inviter = member(1L, "초대한 사람", null);
+		Member invitee = member(2L, "수락한 사람", "https://example.com/invitee-profile.jpg");
+		SharedPlantInvite invite = SharedPlantInvite.builder()
+			.inviter(inviter)
+			.invitee(invitee)
+			.build();
+		SharedPlant sharedPlant = SharedPlant.builder().build();
+		ReflectionTestUtils.setField(sharedPlant, "id", 10L);
+
+		notificationCommandService.createPlantInviteAcceptedNotification(invitee, invite, sharedPlant);
+
+		ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+		verify(notificationRepository).save(notificationCaptor.capture());
+
+		Notification notification = notificationCaptor.getValue();
+		assertThat(notification.getType()).isEqualTo(NotificationType.PLANT_INVITE_ACCEPTED);
+		assertThat(notification.getImageUrl()).isEqualTo(invitee.getProfileImageUrl());
+	}
+
 	private Notification notification(Long notificationId, Long receiverId, boolean isRead) {
-		Member receiver = Member.builder().build();
-		ReflectionTestUtils.setField(receiver, "id", receiverId);
+		Member receiver = member(receiverId, null, null);
 
 		Notification notification = Notification.builder()
 			.receiver(receiver)
@@ -106,5 +129,14 @@ class NotificationCommandServiceImplTest {
 		ReflectionTestUtils.setField(notification, "id", notificationId);
 		ReflectionTestUtils.setField(notification, "createdAt", LocalDateTime.of(2026, 6, 14, 12, 0));
 		return notification;
+	}
+
+	private Member member(Long memberId, String name, String profileImageUrl) {
+		Member member = Member.builder()
+			.name(name)
+			.profileImageUrl(profileImageUrl)
+			.build();
+		ReflectionTestUtils.setField(member, "id", memberId);
+		return member;
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143

## 📝작업 내용

- `PLANT_INVITE_ACCEPTED` 알림 생성 시 초대를 수락한 사용자의 프로필 이미지 URL을 `imageUrl`에 저장하도록 수정했습니다.
- 이에 따라 `GET /api/notifications` 응답에서 해당 알림의 수락자 프로필 이미지를 바로 사용할 수 있습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

없음

## 📌참고 사항

- 알림 생성 시점의 수락자 프로필 이미지 URL이 저장됩니다.
- `NotificationCommandServiceImplTest`, `NotificationQueryServiceImplTest`를 실행해 검증했습니다.

## 💬리뷰 요구사항 

없음
