### PR TITLE
[fix] 초대 발송 알림에 발신자 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -109,7 +109,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 			NotificationSection.GARDEN,
 			NotificationType.PLANT_INVITE,
 			actor.getName() + "님이 초대장을 보냈어요.",
-			null,
+			actor.getProfileImageUrl(),
 			NotificationTargetType.SHARED_PLANT_INVITE,
 			invite.getId()
 		);

--- a/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
+++ b/src/test/java/com/cotato/itda/domain/notification/service/command/NotificationCommandServiceImplTest.java
@@ -92,6 +92,26 @@ class NotificationCommandServiceImplTest {
 	}
 
 	@Test
+	void createPlantInviteNotification_uses_actor_profile_image() {
+		Member inviter = member(1L, "초대한 사람", "https://example.com/inviter-profile.jpg");
+		Member invitee = member(2L, "초대받은 사람", null);
+		SharedPlantInvite invite = SharedPlantInvite.builder()
+			.inviter(inviter)
+			.invitee(invitee)
+			.build();
+		ReflectionTestUtils.setField(invite, "id", 10L);
+
+		notificationCommandService.createPlantInviteNotification(inviter, invite);
+
+		ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+		verify(notificationRepository).save(notificationCaptor.capture());
+
+		Notification notification = notificationCaptor.getValue();
+		assertThat(notification.getType()).isEqualTo(NotificationType.PLANT_INVITE);
+		assertThat(notification.getImageUrl()).isEqualTo(inviter.getProfileImageUrl());
+	}
+
+	@Test
 	void createPlantInviteAcceptedNotification_uses_actor_profile_image() {
 		Member inviter = member(1L, "초대한 사람", null);
 		Member invitee = member(2L, "수락한 사람", "https://example.com/invitee-profile.jpg");


### PR DESCRIPTION
## #️⃣연관된 이슈

- #143

## 📝작업 내용

- `PLANT_INVITE` 알림 생성 시 초대를 보낸 사용자의 프로필 이미지 URL을 `imageUrl`에 저장하도록 수정했습니다.
- 이에 따라 `GET /api/notifications` 응답에서 초대 발송자의 프로필 이미지를 바로 사용할 수 있습니다.

## 🛠️주요 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [x] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷

없음

## 📌참고 사항

- 운영 DB의 기존 `PLANT_INVITE` NULL 이미지 데이터도 초대자 프로필 URL로 백필했습니다.
- 알림 command/query 테스트를 실행해 검증했습니다.

## 💬리뷰 요구사항

없음