### PR TITLE
[feat] 채팅 답장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ out/
 src/main/generated
 
 /GEMINI.md
+
+stomp-test.html

--- a/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageItemDto.java
+++ b/src/main/java/com/cotato/itda/domain/chat/controller/dto/ChatMessageItemDto.java
@@ -30,7 +30,10 @@ public record ChatMessageItemDto(
 	LocalDateTime createdAt,
 
 	@Schema(description = "첨부 메타(없으면 null)")
-	AttachmentMeta attachment
+	AttachmentMeta attachment,
+
+    @Schema(description = "답장 대상 메시지 정보 (일반 메시지면 null)")
+    ReplyTargetInfo replyTarget
 ) {
 	/**
 	 * 첨부 메타(voice/image/file 공통)
@@ -55,4 +58,25 @@ public record ChatMessageItemDto(
 		@Schema(description = "음성 길이(ms) - 음성이 아니면 null", example = "4300")
 		Integer durationMs
 	) {}
+
+    /**
+     * 답장 대상 메시지 정보
+     */
+    @Builder
+    public record ReplyTargetInfo(
+            @Schema(description = "원본 메시지 ID", example = "1")
+            Long messageId,
+
+            @Schema(description = "원본 메시지 발신자 ID", example = "1")
+            Long senderId,
+
+            @Schema(description = "원본 메시지 발신자 닉네임", example = "홍길동")
+            String senderNickname,
+
+            @Schema(description = "원본 메시지 타입(TEXT/ATTACHMENT)", example = "TEXT")
+            MessageType messageType,
+
+            @Schema(description = "원본 메시지 내용 미리보기 (텍스트면 본문 내용, 사진이면 '[사진]')", example = "오늘 회의 몇 시야?")
+            String contentPreview
+    ) {}
 }

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatMessage.java
@@ -14,7 +14,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
@@ -71,6 +70,10 @@ public class ChatMessage extends BaseTimeEntity {
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_message_id")
+    private ChatMessage parentMessage;
 
 	@Builder
 	private ChatMessage(Member sender, ChatRoom room, long messageSeq, MessageType messageType, String content) {

--- a/src/main/java/com/cotato/itda/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/cotato/itda/domain/chat/entity/ChatMessage.java
@@ -76,12 +76,13 @@ public class ChatMessage extends BaseTimeEntity {
     private ChatMessage parentMessage;
 
 	@Builder
-	private ChatMessage(Member sender, ChatRoom room, long messageSeq, MessageType messageType, String content) {
+	private ChatMessage(Member sender, ChatRoom room, long messageSeq, MessageType messageType, String content, ChatMessage parentMessage) {
 		this.sender = sender;
 		this.room = room;
 		this.messageSeq = messageSeq;
 		this.messageType = messageType;
 		this.content = content;
+        this.parentMessage = parentMessage;
 	}
 
 	public void markAsEdited(String newContent, LocalDateTime editedAt) {
@@ -95,13 +96,14 @@ public class ChatMessage extends BaseTimeEntity {
 
 	// 채팅 메시지 생성
 	public static ChatMessage createChatMessage(Member sender, ChatRoom room, long messageSeq, MessageType messageType,
-		String content) {
+		String content, ChatMessage parentMessage) {
 		return ChatMessage.builder()
 			.sender(sender)
 			.room(room)
 			.messageSeq(messageSeq)
 			.messageType(messageType)
 			.content(content)
+            .parentMessage(parentMessage)
 			.build();
 	}
 

--- a/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
@@ -55,7 +55,14 @@ public enum ChatErrorCode implements ErrorCode {
 		"CHAT_ERROR_400_INVALID_CURSOR"
 	),
 
-	// 쫓겨난 상태에서는 다시 방에 참여할 수 없음
+    // 유효하지 않은 채팅방
+    INVALID_CHAT_ROOM(
+        HttpStatus.BAD_REQUEST,
+        "유효하지 않은 채팅방입니다.",
+        "CHAT_ERROR_400_INVALID_CHAT_ROOM"
+    ),
+
+    // 쫓겨난 상태에서는 다시 방에 참여할 수 없음
 	CHAT_ROOM_MEMBER_CREATE_FORBIDDEN(
 		HttpStatus.FORBIDDEN,
 		"채팅 방에 참여할 수 있는 권한이 없습니다.",
@@ -85,7 +92,7 @@ public enum ChatErrorCode implements ErrorCode {
 		"CHAT_ERROR_404_MESSAGE_NOT_FOUND"
 	);
 
-	private final HttpStatus httpStatus;
+    private final HttpStatus httpStatus;
 	private final String message;
 	private final String code;
 }

--- a/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/cotato/itda/domain/chat/exception/code/ChatErrorCode.java
@@ -90,6 +90,13 @@ public enum ChatErrorCode implements ErrorCode {
 		HttpStatus.NOT_FOUND,
 		"채팅 메시지를 찾을 수 없습니다.",
 		"CHAT_ERROR_404_MESSAGE_NOT_FOUND"
+	),
+
+	// 삭제된 메시지에는 답장 불가
+	CHAT_MESSAGE_DELETED(
+		HttpStatus.BAD_REQUEST,
+		"삭제된 메시지에는 답장할 수 없습니다.",
+		"CHAT_ERROR_400_MESSAGE_DELETED"
 	);
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessageAttachmentRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessageAttachmentRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.repository.query.Param;
 import com.cotato.itda.domain.chat.entity.ChatMessageAttachment;
 
 public interface ChatMessageAttachmentRepository extends JpaRepository<ChatMessageAttachment,Long> {
-	interface AttachmentAccessView {
+    Optional<ChatMessageAttachment> findByMessageId(Long messageId);
+
+    interface AttachmentAccessView {
 		Long getAttachmentId();
 		Long getRoomId();
 		Long getMessageId();

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatMessageRepository.java
@@ -1,4 +1,4 @@
-package com.cotato.itda.domain.chat.repository.dto;
+package com.cotato.itda.domain.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
@@ -10,6 +10,7 @@ import com.cotato.itda.domain.chat.entity.QChatMessage;
 import com.cotato.itda.domain.chat.entity.QChatMessageAttachment;
 import com.cotato.itda.domain.chat.entity.QChatRoom;
 import com.cotato.itda.domain.chat.entity.QChatRoomMember;
+import com.cotato.itda.domain.friendship.entity.QFriendship;
 import com.cotato.itda.domain.chat.enums.MemberRoomStatus;
 import com.cotato.itda.domain.chat.enums.RoomType;
 import com.cotato.itda.domain.chat.repository.dto.MessageRow;
@@ -177,12 +178,18 @@ public class ChatRoomQueryRepository {
 	 */
 	public List<MessageRow> findRoomMessagesSlice(
 		Long roomId,
+        Long memberId,
 		Long cursorSeq,
 		Long visibleFromSeq, //이 seq부터는 이 사람이 볼 수 있다 (재입장 이후)
 		int limitPlusOne
 	){
+
 		QChatMessage m = QChatMessage.chatMessage;
 		QChatMessageAttachment a = QChatMessageAttachment.chatMessageAttachment;
+
+        QChatMessage parentMsg = new QChatMessage("parentMsg");
+        QMember parentSender = new QMember("parentSender");
+        QFriendship friendship = QFriendship.friendship;
 
 		BooleanBuilder where = new BooleanBuilder();
 		where.and(m.room.id.eq(roomId));
@@ -220,10 +227,26 @@ public class ChatRoomQueryRepository {
 				a.mimeType,
 				a.sizeBytes,
 				a.status,
-				a.durationMs
+				a.durationMs,
+
+                // MessageRow 생성자에 부모 메시지 정보 순서대로 매핑
+                parentMsg.id,
+                parentSender.id,
+                // 친구 닉네임 없으면 원래 멤버의 이름 사용(coalesce)
+                friendship.nickname.coalesce(parentSender.name),
+                parentMsg.messageType,
+                parentMsg.content
 			))
 			.from(m)
 			.leftJoin(a).on(a.message.eq(m))
+
+            .leftJoin(m.parentMessage, parentMsg)      // 내 메시지 -> 부모 메시지 연결
+            .leftJoin(parentMsg.sender, parentSender)   // 부모 메시지 -> 부모 발신자 연결
+            .leftJoin(friendship).on(                  // 부모 발신자 -> 친구 목록 매핑 조건
+                   friendship.member.id.eq(memberId)
+                        .and(friendship.friend.id.eq(parentSender.id))
+                )
+
 			.where(where)
 			.orderBy(m.messageSeq.desc())
 			.limit(limitPlusOne)

--- a/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/ChatRoomQueryRepository.java
@@ -188,6 +188,7 @@ public class ChatRoomQueryRepository {
 		QChatMessageAttachment a = QChatMessageAttachment.chatMessageAttachment;
 
         QChatMessage parentMsg = new QChatMessage("parentMsg");
+        QChatMessageAttachment parentAttachment = new QChatMessageAttachment("parentAttachment");
         QMember parentSender = new QMember("parentSender");
         QFriendship friendship = QFriendship.friendship;
 
@@ -235,14 +236,16 @@ public class ChatRoomQueryRepository {
                 // 친구 닉네임 없으면 원래 멤버의 이름 사용(coalesce)
                 friendship.nickname.coalesce(parentSender.name),
                 parentMsg.messageType,
-                parentMsg.content
+                parentMsg.content,
+                parentAttachment.attachmentType
 			))
 			.from(m)
 			.leftJoin(a).on(a.message.eq(m))
 
-            .leftJoin(m.parentMessage, parentMsg)      // 내 메시지 -> 부모 메시지 연결
-            .leftJoin(parentMsg.sender, parentSender)   // 부모 메시지 -> 부모 발신자 연결
-            .leftJoin(friendship).on(                  // 부모 발신자 -> 친구 목록 매핑 조건
+            .leftJoin(m.parentMessage, parentMsg)
+            .leftJoin(parentMsg.sender, parentSender)
+            .leftJoin(parentAttachment).on(parentAttachment.message.eq(parentMsg))
+            .leftJoin(friendship).on(
                    friendship.member.id.eq(memberId)
                         .and(friendship.friend.id.eq(parentSender.id))
                 )

--- a/src/main/java/com/cotato/itda/domain/chat/repository/dto/MessageRow.java
+++ b/src/main/java/com/cotato/itda/domain/chat/repository/dto/MessageRow.java
@@ -7,7 +7,7 @@ import com.cotato.itda.domain.chat.enums.AttachmentType;
 import com.cotato.itda.domain.chat.enums.MessageType;
 
 /**
- * 히스토리 조회용 row (메시지 + 첨부 join)
+ * 히스토리 조회용 row (메시지 + 첨부 join + 답장 원본 메시지 join)
  * - attachment는 없을 수 있으니 nullable
  */
 public record MessageRow (
@@ -23,5 +23,12 @@ public record MessageRow (
 	String mimeType,
 	Long sizeBytes,
 	AttachmentStatus attachmentStatus,
-	Integer durationMs
+	Integer durationMs,
+
+    Long parentMessageId,
+    Long parentSenderId,
+    String parentSenderNickname,
+    MessageType parentMessageType,
+    String parentContent,
+    AttachmentType parentAttachmentType
 	){}

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -370,7 +370,7 @@ public class ChatMessageService {
 		// null이면 한 번도 나가지 않은 것
 		Long visibleFromSeq = myMembership.getJoinSeq();
 
-		List<MessageRow> fetched = chatRoomQueryRepository.findRoomMessagesSlice(roomId, cursorSeq,visibleFromSeq, limitPlusOne);
+		List<MessageRow> fetched = chatRoomQueryRepository.findRoomMessagesSlice(roomId, memberId, cursorSeq,visibleFromSeq, limitPlusOne);
 
 		boolean hasNext = fetched.size() > safeLimit;
 		List<MessageRow> page = hasNext ? fetched.subList(0, safeLimit) : fetched;

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -24,7 +24,7 @@ import com.cotato.itda.domain.chat.repository.ChatMessageAttachmentRepository;
 import com.cotato.itda.domain.chat.repository.ChatRoomMemberRepository;
 import com.cotato.itda.domain.chat.repository.ChatRoomQueryRepository;
 import com.cotato.itda.domain.chat.repository.ChatRoomRepository;
-import com.cotato.itda.domain.chat.repository.dto.ChatMessageRepository;
+import com.cotato.itda.domain.chat.repository.ChatMessageRepository;
 import com.cotato.itda.domain.chat.repository.dto.MessageRow;
 import com.cotato.itda.domain.member.entity.Member;
 import com.cotato.itda.domain.member.repository.MemberRepository;
@@ -38,6 +38,8 @@ import com.cotato.itda.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.cotato.itda.domain.chat.enums.AttachmentType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -175,8 +177,21 @@ public class ChatMessageService {
         }
 		log.info("[seq 발급] roomId={}, lastSeq={}, nextSeq={}", roomId, lastSeq, nextSeq);
 
+        ChatMessage parentMessage = null;
+        if (req.parentMessageId() != null) {
+            parentMessage = chatMessageRepository.findById(req.parentMessageId())
+                    .orElseThrow(() -> {
+                        log.warn("[답장 실패] 원본 메시지 없음 parentMessageId={}", req.parentMessageId());
+                        return new BusinessException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND);
+                    });
+            if (!parentMessage.getRoom().getId().equals(roomId)) {
+                throw new BusinessException(ChatErrorCode.INVALID_CHAT_ROOM);
+            }
+        }
+
+
         ChatMessage message = ChatMessage.createChatMessage(
-                sender, room, nextSeq, req.messageType(), req.content()
+                sender, room, nextSeq, req.messageType(), req.content(), parentMessage
         );
         chatMessageRepository.save(message);
 
@@ -256,6 +271,32 @@ public class ChatMessageService {
 
 
 		// ===== [8] 방 토픽 발행 =====
+        ChatRoomMessageDto.ReplyTargetInfo replyTargetDto = null;
+
+        if (parentMessage != null) {
+            String replyPreview;
+            ChatMessageAttachment parentAttachment = chatMessageAttachmentRepository.findByMessageId(parentMessage.getId()).orElse(null);
+
+            if (parentMessage.getMessageType() == MessageType.ATTACHMENT && parentAttachment != null) {
+                replyPreview = switch (parentAttachment.getAttachmentType()) {
+                    case IMAGE -> "[사진]";
+                    case VOICE -> "[음성 메시지]";
+                    case FILE  -> "[파일]";
+                    default    -> "[첨부파일]";
+                };
+            } else {
+                replyPreview = parentMessage.getContent();
+            }
+
+            replyTargetDto = ChatRoomMessageDto.ReplyTargetInfo.builder()
+                    .messageId(parentMessage.getId())
+                    .senderId(parentMessage.getSender().getId())
+                    .senderNickname(parentMessage.getSender().getName())
+                    .messageType(parentMessage.getMessageType())
+                    .contentPreview(replyPreview)
+                    .build();
+        }
+
 		ChatRoomMessageDto roomMessageDto = ChatRoomMessageDto.builder()
 			.roomId(roomId)
 			.messageId(message.getId())
@@ -265,6 +306,7 @@ public class ChatMessageService {
 			.content(req.content())
 			.createdAt(now)
 			.attachment(meta)
+            .replyTarget(replyTargetDto)
 			.build();
 
 		String roomTopicDest = "/topic/chat/rooms/" + roomId;
@@ -380,22 +422,49 @@ public class ChatMessageService {
 		);
 
 		List<ChatMessageItemDto> items = page.stream()
-			.map(row -> ChatMessageItemDto.builder()
-				.messageId(row.messageId())
-				.messageSeq(row.messageSeq())
-				.senderMemberId(row.senderId())
-				.messageType(row.messageType())
-				.content(row.content())
-				.createdAt(row.createdAt())
-				.attachment(row.attachmentType() == null ? null : ChatMessageItemDto.AttachmentMeta.builder()
-					.attachmentType(row.attachmentType())
-					.objectKey(row.objectKey())
-					.mimeType(row.mimeType())
-					.sizeBytes(row.sizeBytes())
-					.status(row.attachmentStatus())
-					.durationMs(row.durationMs())
-					.build())
-				.build())
+			.map(row -> {
+
+                ChatMessageItemDto.ReplyTargetInfo replyTarget = null;
+                if (row.parentMessageId() != null) {
+                    String preview;
+                    if (row.parentMessageType() == MessageType.ATTACHMENT && row.parentAttachmentType() != null) {
+                        preview = switch (row.parentAttachmentType()) {
+                            case IMAGE -> "[사진]";
+                            case VOICE -> "[음성 메시지]";
+                            case FILE -> "[파일]";
+                            default -> "[첨부파일]";
+                        };
+                    } else {
+                       preview = row.parentContent();
+                    }
+
+                    replyTarget = ChatMessageItemDto.ReplyTargetInfo.builder()
+                         .messageId(row.parentMessageId())
+                         .senderId(row.parentSenderId())
+                         .senderNickname(row.parentSenderNickname())
+                         .messageType(row.parentMessageType())
+                         .contentPreview(preview)
+                         .build();
+                    }
+
+                    return ChatMessageItemDto.builder()
+                        .messageId(row.messageId())
+                        .messageSeq(row.messageSeq())
+                        .senderMemberId(row.senderId())
+                        .messageType(row.messageType())
+                        .content(row.content())
+                        .createdAt(row.createdAt())
+                        .attachment(row.attachmentType() == null ? null : ChatMessageItemDto.AttachmentMeta.builder()
+                                .attachmentType(row.attachmentType())
+                                .objectKey(row.objectKey())
+                                .mimeType(row.mimeType())
+                                .sizeBytes(row.sizeBytes())
+                                .status(row.attachmentStatus())
+                                .durationMs(row.durationMs())
+                                .build())
+                        .replyTarget(replyTarget)
+                        .build();
+            })
 			.toList();
 
 		Long nextCursor = null;

--- a/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/cotato/itda/domain/chat/service/ChatMessageService.java
@@ -184,6 +184,10 @@ public class ChatMessageService {
                         log.warn("[답장 실패] 원본 메시지 없음 parentMessageId={}", req.parentMessageId());
                         return new BusinessException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND);
                     });
+            if (parentMessage.getDeletedAt() != null) {
+                log.warn("[답장 실패] 삭제된 메시지에 답장 시도 parentMessageId={}", req.parentMessageId());
+                throw new BusinessException(ChatErrorCode.CHAT_MESSAGE_DELETED);
+            }
             if (!parentMessage.getRoom().getId().equals(roomId)) {
                 throw new BusinessException(ChatErrorCode.INVALID_CHAT_ROOM);
             }

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatRoomMessageDto.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatRoomMessageDto.java
@@ -21,7 +21,8 @@ public record ChatRoomMessageDto(
 	MessageType messageType,
 	String content,
 	LocalDateTime createdAt,
-	ChatMessageItemDto.AttachmentMeta attachment
+	ChatMessageItemDto.AttachmentMeta attachment,
+    ReplyTargetInfo replyTarget
 ) {
 	@Builder
 	public record Attachment(
@@ -32,4 +33,13 @@ public record ChatRoomMessageDto(
 		AttachmentStatus status,
 		Integer durationMs
 	) {}
+
+    @Builder
+    public record ReplyTargetInfo(
+            Long messageId,
+            Long senderId,
+            String senderNickname,
+            MessageType messageType,
+            String contentPreview   // TEXT면 내용 일부, ATTACHMENT면 타입별 별칭([사진], [음성 메시지] 등)
+    ) {}
 }

--- a/src/main/java/com/cotato/itda/domain/websocket/dto/ChatSendMessageRequest.java
+++ b/src/main/java/com/cotato/itda/domain/websocket/dto/ChatSendMessageRequest.java
@@ -22,6 +22,7 @@ public record ChatSendMessageRequest(
 	Long opponentMemberId, // roomId가 없을 때 필수
 	@NotNull MessageType messageType,
 	String content,
-	ChatAttachmentRequest attachment
+	ChatAttachmentRequest attachment,
+    Long parentMessageId
 	){
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 해당 PR과 관련된 이슈 번호를 적어주세요. ex) #이슈번호 -->
#145 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 채팅 메시지 답장 기능을 구현했습니다. 
- 메시지 전송 시 parentMessageId를 포함하면 해당 메시지에 대한 답장으로 처리되며, 실시간 WebSocket 이벤트와 메시지 목록 조회 API 모두에서 원본 메시지 정보를 함께 반환합니다.

## 🛠️주요 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 코드 리팩토링
- [ ] 테스트 추가 또는 수정
- [ ] 의존성 추가/삭제

## 📸스크린샷 

## 💬리뷰 요구사항 

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 답장 메시지 전송/조회 시, parentMessageId과 함께 원본 메시지 정보를 넘겨주는 구조가 적절한지 확인 부탁드립니다.

- 현재 구현된 예외 처리 외에, 추가로 고려해야 할 예외 처리가 있다면 말씀 부탁드립니다.
  - 존재하지 않는 원본 메시지: parentMessageId에 해당하는 원본 메시지가 존재하지 않는 경우
  - 채팅방 불일치: parentMessageId에 해당하는 원본 메시지가 존재하지만, 현재 전송하려는 roomId와 일치하지 않는 경우